### PR TITLE
[Label Redesign] Passing label id to entity_exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ DATA = age--1.3.0.sql
 
 # sorted in dependency order
 REGRESS = label_redesign_rafsun \
+          label_redesign_wendel \
           scan \
           graphid \
           agtype \

--- a/regress/expected/cypher_create.out
+++ b/regress/expected/cypher_create.out
@@ -47,11 +47,11 @@ SELECT * FROM cypher('cypher_create', $$CREATE (:v {key: 'value'})$$) AS (a agty
 (0 rows)
 
 SELECT * FROM cypher('cypher_create', $$MATCH (n:v) RETURN n$$) AS (n agtype);
-                                       n                                       
--------------------------------------------------------------------------------
- {"id": 844424930131969, "label": "v", "properties": {}}::vertex
- {"id": 844424930131970, "label": "v", "properties": {}}::vertex
- {"id": 844424930131971, "label": "v", "properties": {"key": "value"}}::vertex
+                                n                                
+-----------------------------------------------------------------
+ {"id": 2, "label": "v", "properties": {}}::vertex
+ {"id": 3, "label": "v", "properties": {}}::vertex
+ {"id": 4, "label": "v", "properties": {"key": "value"}}::vertex
 (3 rows)
 
 -- Left relationship
@@ -119,43 +119,43 @@ ERROR:  relationships must be specify a label in CREATE.
 LINE 1: ...LECT * FROM cypher('cypher_create', $$CREATE (:v)-[]->(:v)$$...
                                                              ^
 SELECT * FROM cypher_create.e;
-        id        |    start_id     |     end_id      |           properties           
-------------------+-----------------+-----------------+--------------------------------
- 1125899906842625 | 844424930131972 | 844424930131973 | {"id": "right rel"}
- 1125899906842626 | 844424930131975 | 844424930131974 | {"id": "left rel"}
- 1125899906842627 | 844424930131977 | 844424930131978 | {"id": "path, edge two"}
- 1125899906842628 | 844424930131976 | 844424930131977 | {"id": "path, edge one"}
- 1125899906842629 | 844424930131980 | 844424930131981 | {"id": "divergent, edge two"}
- 1125899906842630 | 844424930131980 | 844424930131979 | {"id": "divergent, edge one"}
- 1125899906842631 | 844424930131984 | 844424930131983 | {"id": "convergent, edge two"}
- 1125899906842632 | 844424930131982 | 844424930131983 | {"id": "convergent, edge one"}
- 1125899906842633 | 844424930131985 | 844424930131986 | {"id": "paths, edge one"}
- 1125899906842634 | 844424930131987 | 844424930131988 | {"id": "paths, edge two"}
+ id | start_id | end_id |           properties           | label_id 
+----+----------+--------+--------------------------------+----------
+  1 |        5 |      6 | {"id": "right rel"}            |        4
+  2 |        8 |      7 | {"id": "left rel"}             |        4
+  3 |       10 |     11 | {"id": "path, edge two"}       |        4
+  4 |        9 |     10 | {"id": "path, edge one"}       |        4
+  5 |       13 |     14 | {"id": "divergent, edge two"}  |        4
+  6 |       13 |     12 | {"id": "divergent, edge one"}  |        4
+  7 |       17 |     16 | {"id": "convergent, edge two"} |        4
+  8 |       15 |     16 | {"id": "convergent, edge one"} |        4
+  9 |       18 |     19 | {"id": "paths, edge one"}      |        4
+ 10 |       20 |     21 | {"id": "paths, edge two"}      |        4
 (10 rows)
 
 SELECT * FROM cypher_create.v;
-       id        |             properties             
------------------+------------------------------------
- 844424930131969 | {}
- 844424930131970 | {}
- 844424930131971 | {"key": "value"}
- 844424930131972 | {"id": "right rel, initial node"}
- 844424930131973 | {"id": "right rel, end node"}
- 844424930131974 | {"id": "left rel, initial node"}
- 844424930131975 | {"id": "left rel, end node"}
- 844424930131976 | {"id": "path, initial node"}
- 844424930131977 | {"id": "path, middle node"}
- 844424930131978 | {"id": "path, last node"}
- 844424930131979 | {"id": "divergent, initial node"}
- 844424930131980 | {"id": "divergent middle node"}
- 844424930131981 | {"id": "divergent, end node"}
- 844424930131982 | {"id": "convergent, initial node"}
- 844424930131983 | {"id": "convergent middle node"}
- 844424930131984 | {"id": "convergent, end node"}
- 844424930131985 | {"id": "paths, vertex one"}
- 844424930131986 | {"id": "paths, vertex two"}
- 844424930131987 | {"id": "paths, vertex three"}
- 844424930131988 | {"id": "paths, vertex four"}
+ id |             properties             | label_id 
+----+------------------------------------+----------
+  2 | {}                                 |        3
+  3 | {}                                 |        3
+  4 | {"key": "value"}                   |        3
+  5 | {"id": "right rel, initial node"}  |        3
+  6 | {"id": "right rel, end node"}      |        3
+  7 | {"id": "left rel, initial node"}   |        3
+  8 | {"id": "left rel, end node"}       |        3
+  9 | {"id": "path, initial node"}       |        3
+ 10 | {"id": "path, middle node"}        |        3
+ 11 | {"id": "path, last node"}          |        3
+ 12 | {"id": "divergent, initial node"}  |        3
+ 13 | {"id": "divergent middle node"}    |        3
+ 14 | {"id": "divergent, end node"}      |        3
+ 15 | {"id": "convergent, initial node"} |        3
+ 16 | {"id": "convergent middle node"}   |        3
+ 17 | {"id": "convergent, end node"}     |        3
+ 18 | {"id": "paths, vertex one"}        |        3
+ 19 | {"id": "paths, vertex two"}        |        3
+ 20 | {"id": "paths, vertex three"}      |        3
+ 21 | {"id": "paths, vertex four"}       |        3
 (20 rows)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -217,27 +217,27 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (a)-[:b_var]->()
 	RETURN a, id(a)
 $$) as (a agtype, b agtype);
-                               a                                |        b        
-----------------------------------------------------------------+-----------------
- {"id": 281474976710659, "label": "", "properties": {}}::vertex | 281474976710659
+                         a                         | b  
+---------------------------------------------------+----
+ {"id": 29, "label": "", "properties": {}}::vertex | 29
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE ()-[b:e_var]->()
 	RETURN b, id(b)
 $$) as (a agtype, b agtype);
-                                                             a                                                              |        b         
-----------------------------------------------------------------------------------------------------------------------------+------------------
- {"id": 1688849860263950, "label": "e_var", "end_id": 281474976710662, "start_id": 281474976710661, "properties": {}}::edge | 1688849860263950
+                                         a                                          | b  
+------------------------------------------------------------------------------------+----
+ {"id": 25, "label": "e_var", "end_id": 32, "start_id": 31, "properties": {}}::edge | 25
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE (a)-[b:e_var {id: 0}]->()
 	RETURN a, b, b.id, b.id + 1
 $$) as (a agtype, b agtype, c agtype, d agtype);
-                               a                                |                                                                 b                                                                 | c | d 
-----------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+---+---
- {"id": 281474976710663, "label": "", "properties": {}}::vertex | {"id": 1688849860263951, "label": "e_var", "end_id": 281474976710664, "start_id": 281474976710663, "properties": {"id": 0}}::edge | 0 | 1
+                         a                         |                                             b                                             | c | d 
+---------------------------------------------------+-------------------------------------------------------------------------------------------+---+---
+ {"id": 33, "label": "", "properties": {}}::vertex | {"id": 26, "label": "e_var", "end_id": 34, "start_id": 33, "properties": {"id": 0}}::edge | 0 | 1
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -245,11 +245,11 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (a)-[b:e_var]->(a)
 	RETURN a, b
 $$) as (a agtype, b agtype);
-                                          a                                           |                                                              b                                                               
---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------
- {"id": 1407374883553281, "label": "n_var", "properties": {"name": "Node A"}}::vertex | {"id": 1688849860263952, "label": "e_var", "end_id": 1407374883553281, "start_id": 1407374883553281, "properties": {}}::edge
- {"id": 1407374883553282, "label": "n_var", "properties": {"name": "Node B"}}::vertex | {"id": 1688849860263953, "label": "e_var", "end_id": 1407374883553282, "start_id": 1407374883553282, "properties": {}}::edge
- {"id": 1407374883553283, "label": "n_var", "properties": {"name": "Node C"}}::vertex | {"id": 1688849860263954, "label": "e_var", "end_id": 1407374883553283, "start_id": 1407374883553283, "properties": {}}::edge
+                                   a                                    |                                         b                                          
+------------------------------------------------------------------------+------------------------------------------------------------------------------------
+ {"id": 22, "label": "n_var", "properties": {"name": "Node A"}}::vertex | {"id": 27, "label": "e_var", "end_id": 22, "start_id": 22, "properties": {}}::edge
+ {"id": 23, "label": "n_var", "properties": {"name": "Node B"}}::vertex | {"id": 28, "label": "e_var", "end_id": 23, "start_id": 23, "properties": {}}::edge
+ {"id": 24, "label": "n_var", "properties": {"name": "Node C"}}::vertex | {"id": 29, "label": "e_var", "end_id": 24, "start_id": 24, "properties": {}}::edge
 (3 rows)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -257,47 +257,47 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (a)-[b:e_var]->(c)
 	RETURN a, b, c
 $$) as (a agtype, b agtype, c agtype);
-                                          a                                           |                                                              b                                                              |                               c                                
---------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------
- {"id": 1407374883553281, "label": "n_var", "properties": {"name": "Node A"}}::vertex | {"id": 1688849860263955, "label": "e_var", "end_id": 281474976710665, "start_id": 1407374883553281, "properties": {}}::edge | {"id": 281474976710665, "label": "", "properties": {}}::vertex
- {"id": 1407374883553282, "label": "n_var", "properties": {"name": "Node B"}}::vertex | {"id": 1688849860263956, "label": "e_var", "end_id": 281474976710666, "start_id": 1407374883553282, "properties": {}}::edge | {"id": 281474976710666, "label": "", "properties": {}}::vertex
- {"id": 1407374883553283, "label": "n_var", "properties": {"name": "Node C"}}::vertex | {"id": 1688849860263957, "label": "e_var", "end_id": 281474976710667, "start_id": 1407374883553283, "properties": {}}::edge | {"id": 281474976710667, "label": "", "properties": {}}::vertex
+                                   a                                    |                                         b                                          |                         c                         
+------------------------------------------------------------------------+------------------------------------------------------------------------------------+---------------------------------------------------
+ {"id": 22, "label": "n_var", "properties": {"name": "Node A"}}::vertex | {"id": 30, "label": "e_var", "end_id": 35, "start_id": 22, "properties": {}}::edge | {"id": 35, "label": "", "properties": {}}::vertex
+ {"id": 23, "label": "n_var", "properties": {"name": "Node B"}}::vertex | {"id": 31, "label": "e_var", "end_id": 36, "start_id": 23, "properties": {}}::edge | {"id": 36, "label": "", "properties": {}}::vertex
+ {"id": 24, "label": "n_var", "properties": {"name": "Node C"}}::vertex | {"id": 32, "label": "e_var", "end_id": 37, "start_id": 24, "properties": {}}::edge | {"id": 37, "label": "", "properties": {}}::vertex
 (3 rows)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE (a)-[:e_var]->()
 	RETURN a
 $$) as (b agtype);
-                               b                                
-----------------------------------------------------------------
- {"id": 281474976710668, "label": "", "properties": {}}::vertex
+                         b                         
+---------------------------------------------------
+ {"id": 38, "label": "", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE ()-[b:e_var]->()
 	RETURN b
 $$) as (b agtype);
-                                                             b                                                              
-----------------------------------------------------------------------------------------------------------------------------
- {"id": 1688849860263959, "label": "e_var", "end_id": 281474976710671, "start_id": 281474976710670, "properties": {}}::edge
+                                         b                                          
+------------------------------------------------------------------------------------
+ {"id": 34, "label": "e_var", "end_id": 41, "start_id": 40, "properties": {}}::edge
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE p=()-[:e_var]->()
 	RETURN p
 $$) as (b agtype);
-                                                                                                                                 b                                                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710672, "label": "", "properties": {}}::vertex, {"id": 1688849860263960, "label": "e_var", "end_id": 281474976710673, "start_id": 281474976710672, "properties": {}}::edge, {"id": 281474976710673, "label": "", "properties": {}}::vertex]::path
+                                                                                                b                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 42, "label": "", "properties": {}}::vertex, {"id": 35, "label": "e_var", "end_id": 43, "start_id": 42, "properties": {}}::edge, {"id": 43, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE p=(a {id:0})-[:e_var]->(a)
 	RETURN p
 $$) as (b agtype);
-                                                                                                                                        b                                                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710674, "label": "", "properties": {"id": 0}}::vertex, {"id": 1688849860263961, "label": "e_var", "end_id": 281474976710674, "start_id": 281474976710674, "properties": {}}::edge, {"id": 281474976710674, "label": "", "properties": {"id": 0}}::vertex]::path
+                                                                                                       b                                                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 44, "label": "", "properties": {"id": 0}}::vertex, {"id": 36, "label": "e_var", "end_id": 44, "start_id": 44, "properties": {}}::edge, {"id": 44, "label": "", "properties": {"id": 0}}::vertex]::path
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -305,20 +305,20 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE p=(a)-[:e_var]->(a)
 	RETURN p
 $$) as (b agtype);
-                                                                                                                                                        b                                                                                                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 1407374883553281, "label": "n_var", "properties": {"name": "Node A"}}::vertex, {"id": 1688849860263962, "label": "e_var", "end_id": 1407374883553281, "start_id": 1407374883553281, "properties": {}}::edge, {"id": 1407374883553281, "label": "n_var", "properties": {"name": "Node A"}}::vertex]::path
- [{"id": 1407374883553282, "label": "n_var", "properties": {"name": "Node B"}}::vertex, {"id": 1688849860263963, "label": "e_var", "end_id": 1407374883553282, "start_id": 1407374883553282, "properties": {}}::edge, {"id": 1407374883553282, "label": "n_var", "properties": {"name": "Node B"}}::vertex]::path
- [{"id": 1407374883553283, "label": "n_var", "properties": {"name": "Node C"}}::vertex, {"id": 1688849860263964, "label": "e_var", "end_id": 1407374883553283, "start_id": 1407374883553283, "properties": {}}::edge, {"id": 1407374883553283, "label": "n_var", "properties": {"name": "Node C"}}::vertex]::path
+                                                                                                                     b                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 22, "label": "n_var", "properties": {"name": "Node A"}}::vertex, {"id": 37, "label": "e_var", "end_id": 22, "start_id": 22, "properties": {}}::edge, {"id": 22, "label": "n_var", "properties": {"name": "Node A"}}::vertex]::path
+ [{"id": 23, "label": "n_var", "properties": {"name": "Node B"}}::vertex, {"id": 38, "label": "e_var", "end_id": 23, "start_id": 23, "properties": {}}::edge, {"id": 23, "label": "n_var", "properties": {"name": "Node B"}}::vertex]::path
+ [{"id": 24, "label": "n_var", "properties": {"name": "Node C"}}::vertex, {"id": 39, "label": "e_var", "end_id": 24, "start_id": 24, "properties": {}}::edge, {"id": 24, "label": "n_var", "properties": {"name": "Node C"}}::vertex]::path
 (3 rows)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE p=(a)-[:e_var]->(), (a)-[b:e_var]->(a)
 	RETURN p, b
 $$) as (a agtype, b agtype);
-                                                                                                                                 a                                                                                                                                  |                                                             b                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710675, "label": "", "properties": {}}::vertex, {"id": 1688849860263965, "label": "e_var", "end_id": 281474976710676, "start_id": 281474976710675, "properties": {}}::edge, {"id": 281474976710676, "label": "", "properties": {}}::vertex]::path | {"id": 1688849860263966, "label": "e_var", "end_id": 281474976710675, "start_id": 281474976710675, "properties": {}}::edge
+                                                                                                a                                                                                                 |                                         b                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------
+ [{"id": 45, "label": "", "properties": {}}::vertex, {"id": 40, "label": "e_var", "end_id": 46, "start_id": 45, "properties": {}}::edge, {"id": 46, "label": "", "properties": {}}::vertex]::path | {"id": 41, "label": "e_var", "end_id": 45, "start_id": 45, "properties": {}}::edge
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -332,46 +332,46 @@ $$) as (a agtype);
 (0 rows)
 
 SELECT * FROM cypher_create.n_var;
-        id        |     properties     
-------------------+--------------------
- 1407374883553281 | {"name": "Node A"}
- 1407374883553282 | {"name": "Node B"}
- 1407374883553283 | {"name": "Node C"}
+ id |     properties     | label_id 
+----+--------------------+----------
+ 22 | {"name": "Node A"} |        5
+ 23 | {"name": "Node B"} |        5
+ 24 | {"name": "Node C"} |        5
 (3 rows)
 
 SELECT * FROM cypher_create.e_var;
-        id        |     start_id     |      end_id      |           properties           
-------------------+------------------+------------------+--------------------------------
- 1688849860263937 | 1407374883553281 | 1407374883553282 | {"name": "Node A -> Node B"}
- 1688849860263938 | 1407374883553281 | 1407374883553283 | {"name": "Node A -> Node C"}
- 1688849860263939 | 1407374883553282 | 1407374883553281 | {"name": "Node B -> Node A"}
- 1688849860263940 | 1407374883553282 | 1407374883553283 | {"name": "Node B -> Node C"}
- 1688849860263941 | 1407374883553283 | 1407374883553281 | {"name": "Node C -> Node A"}
- 1688849860263942 | 1407374883553283 | 1407374883553282 | {"name": "Node C -> Node B"}
- 1688849860263943 | 1407374883553281 | 1407374883553281 | {"name": "Node A -> Node A"}
- 1688849860263944 | 1407374883553282 | 1407374883553282 | {"name": "Node B -> Node B"}
- 1688849860263945 | 1407374883553283 | 1407374883553283 | {"name": "Node C -> Node C"}
- 1688849860263946 | 1407374883553281 | 1970324836974593 | {"name": "Node A -> new node"}
- 1688849860263947 | 1407374883553282 | 1970324836974594 | {"name": "Node B -> new node"}
- 1688849860263948 | 1407374883553283 | 1970324836974595 | {"name": "Node C -> new node"}
- 1688849860263949 | 1407374883553281 | 281474976710658  | {}
- 1688849860263950 | 281474976710661  | 281474976710662  | {}
- 1688849860263951 | 281474976710663  | 281474976710664  | {"id": 0}
- 1688849860263952 | 1407374883553281 | 1407374883553281 | {}
- 1688849860263953 | 1407374883553282 | 1407374883553282 | {}
- 1688849860263954 | 1407374883553283 | 1407374883553283 | {}
- 1688849860263955 | 1407374883553281 | 281474976710665  | {}
- 1688849860263956 | 1407374883553282 | 281474976710666  | {}
- 1688849860263957 | 1407374883553283 | 281474976710667  | {}
- 1688849860263958 | 281474976710668  | 281474976710669  | {}
- 1688849860263959 | 281474976710670  | 281474976710671  | {}
- 1688849860263960 | 281474976710672  | 281474976710673  | {}
- 1688849860263961 | 281474976710674  | 281474976710674  | {}
- 1688849860263962 | 1407374883553281 | 1407374883553281 | {}
- 1688849860263963 | 1407374883553282 | 1407374883553282 | {}
- 1688849860263964 | 1407374883553283 | 1407374883553283 | {}
- 1688849860263965 | 281474976710675  | 281474976710676  | {}
- 1688849860263966 | 281474976710675  | 281474976710675  | {}
+ id | start_id | end_id |           properties           | label_id 
+----+----------+--------+--------------------------------+----------
+ 11 |       22 |     23 | {"name": "Node A -> Node B"}   |        6
+ 12 |       22 |     24 | {"name": "Node A -> Node C"}   |        6
+ 13 |       23 |     22 | {"name": "Node B -> Node A"}   |        6
+ 14 |       23 |     24 | {"name": "Node B -> Node C"}   |        6
+ 15 |       24 |     22 | {"name": "Node C -> Node A"}   |        6
+ 16 |       24 |     23 | {"name": "Node C -> Node B"}   |        6
+ 17 |       22 |     22 | {"name": "Node A -> Node A"}   |        6
+ 18 |       23 |     23 | {"name": "Node B -> Node B"}   |        6
+ 19 |       24 |     24 | {"name": "Node C -> Node C"}   |        6
+ 20 |       22 |     25 | {"name": "Node A -> new node"} |        6
+ 21 |       23 |     26 | {"name": "Node B -> new node"} |        6
+ 22 |       24 |     27 | {"name": "Node C -> new node"} |        6
+ 23 |       22 |     28 | {}                             |        6
+ 25 |       31 |     32 | {}                             |        6
+ 26 |       33 |     34 | {"id": 0}                      |        6
+ 27 |       22 |     22 | {}                             |        6
+ 28 |       23 |     23 | {}                             |        6
+ 29 |       24 |     24 | {}                             |        6
+ 30 |       22 |     35 | {}                             |        6
+ 31 |       23 |     36 | {}                             |        6
+ 32 |       24 |     37 | {}                             |        6
+ 33 |       38 |     39 | {}                             |        6
+ 34 |       40 |     41 | {}                             |        6
+ 35 |       42 |     43 | {}                             |        6
+ 36 |       44 |     44 | {}                             |        6
+ 37 |       22 |     22 | {}                             |        6
+ 38 |       23 |     23 | {}                             |        6
+ 39 |       24 |     24 | {}                             |        6
+ 40 |       45 |     46 | {}                             |        6
+ 41 |       45 |     45 | {}                             |        6
 (30 rows)
 
 --Check every label has been created
@@ -390,81 +390,81 @@ SELECT name, kind FROM ag_label ORDER BY name;
 
 --Validate every vertex has the correct label
 SELECT * FROM cypher('cypher_create', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                                n                                                
--------------------------------------------------------------------------------------------------
- {"id": 281474976710657, "label": "", "properties": {}}::vertex
- {"id": 281474976710658, "label": "", "properties": {}}::vertex
- {"id": 281474976710659, "label": "", "properties": {}}::vertex
- {"id": 281474976710660, "label": "", "properties": {}}::vertex
- {"id": 281474976710661, "label": "", "properties": {}}::vertex
- {"id": 281474976710662, "label": "", "properties": {}}::vertex
- {"id": 281474976710663, "label": "", "properties": {}}::vertex
- {"id": 281474976710664, "label": "", "properties": {}}::vertex
- {"id": 281474976710665, "label": "", "properties": {}}::vertex
- {"id": 281474976710666, "label": "", "properties": {}}::vertex
- {"id": 281474976710667, "label": "", "properties": {}}::vertex
- {"id": 281474976710668, "label": "", "properties": {}}::vertex
- {"id": 281474976710669, "label": "", "properties": {}}::vertex
- {"id": 281474976710670, "label": "", "properties": {}}::vertex
- {"id": 281474976710671, "label": "", "properties": {}}::vertex
- {"id": 281474976710672, "label": "", "properties": {}}::vertex
- {"id": 281474976710673, "label": "", "properties": {}}::vertex
- {"id": 281474976710674, "label": "", "properties": {"id": 0}}::vertex
- {"id": 281474976710675, "label": "", "properties": {}}::vertex
- {"id": 281474976710676, "label": "", "properties": {}}::vertex
- {"id": 844424930131969, "label": "v", "properties": {}}::vertex
- {"id": 844424930131970, "label": "v", "properties": {}}::vertex
- {"id": 844424930131971, "label": "v", "properties": {"key": "value"}}::vertex
- {"id": 844424930131972, "label": "v", "properties": {"id": "right rel, initial node"}}::vertex
- {"id": 844424930131973, "label": "v", "properties": {"id": "right rel, end node"}}::vertex
- {"id": 844424930131974, "label": "v", "properties": {"id": "left rel, initial node"}}::vertex
- {"id": 844424930131975, "label": "v", "properties": {"id": "left rel, end node"}}::vertex
- {"id": 844424930131976, "label": "v", "properties": {"id": "path, initial node"}}::vertex
- {"id": 844424930131977, "label": "v", "properties": {"id": "path, middle node"}}::vertex
- {"id": 844424930131978, "label": "v", "properties": {"id": "path, last node"}}::vertex
- {"id": 844424930131979, "label": "v", "properties": {"id": "divergent, initial node"}}::vertex
- {"id": 844424930131980, "label": "v", "properties": {"id": "divergent middle node"}}::vertex
- {"id": 844424930131981, "label": "v", "properties": {"id": "divergent, end node"}}::vertex
- {"id": 844424930131982, "label": "v", "properties": {"id": "convergent, initial node"}}::vertex
- {"id": 844424930131983, "label": "v", "properties": {"id": "convergent middle node"}}::vertex
- {"id": 844424930131984, "label": "v", "properties": {"id": "convergent, end node"}}::vertex
- {"id": 844424930131985, "label": "v", "properties": {"id": "paths, vertex one"}}::vertex
- {"id": 844424930131986, "label": "v", "properties": {"id": "paths, vertex two"}}::vertex
- {"id": 844424930131987, "label": "v", "properties": {"id": "paths, vertex three"}}::vertex
- {"id": 844424930131988, "label": "v", "properties": {"id": "paths, vertex four"}}::vertex
- {"id": 1407374883553281, "label": "n_var", "properties": {"name": "Node A"}}::vertex
- {"id": 1407374883553282, "label": "n_var", "properties": {"name": "Node B"}}::vertex
- {"id": 1407374883553283, "label": "n_var", "properties": {"name": "Node C"}}::vertex
- {"id": 1970324836974593, "label": "n_other_node", "properties": {}}::vertex
- {"id": 1970324836974594, "label": "n_other_node", "properties": {}}::vertex
- {"id": 1970324836974595, "label": "n_other_node", "properties": {}}::vertex
+                                         n                                          
+------------------------------------------------------------------------------------
+ {"id": 1, "label": "", "properties": {}}::vertex
+ {"id": 28, "label": "", "properties": {}}::vertex
+ {"id": 29, "label": "", "properties": {}}::vertex
+ {"id": 30, "label": "", "properties": {}}::vertex
+ {"id": 31, "label": "", "properties": {}}::vertex
+ {"id": 32, "label": "", "properties": {}}::vertex
+ {"id": 33, "label": "", "properties": {}}::vertex
+ {"id": 34, "label": "", "properties": {}}::vertex
+ {"id": 35, "label": "", "properties": {}}::vertex
+ {"id": 36, "label": "", "properties": {}}::vertex
+ {"id": 37, "label": "", "properties": {}}::vertex
+ {"id": 38, "label": "", "properties": {}}::vertex
+ {"id": 39, "label": "", "properties": {}}::vertex
+ {"id": 40, "label": "", "properties": {}}::vertex
+ {"id": 41, "label": "", "properties": {}}::vertex
+ {"id": 42, "label": "", "properties": {}}::vertex
+ {"id": 43, "label": "", "properties": {}}::vertex
+ {"id": 44, "label": "", "properties": {"id": 0}}::vertex
+ {"id": 45, "label": "", "properties": {}}::vertex
+ {"id": 46, "label": "", "properties": {}}::vertex
+ {"id": 2, "label": "v", "properties": {}}::vertex
+ {"id": 3, "label": "v", "properties": {}}::vertex
+ {"id": 4, "label": "v", "properties": {"key": "value"}}::vertex
+ {"id": 5, "label": "v", "properties": {"id": "right rel, initial node"}}::vertex
+ {"id": 6, "label": "v", "properties": {"id": "right rel, end node"}}::vertex
+ {"id": 7, "label": "v", "properties": {"id": "left rel, initial node"}}::vertex
+ {"id": 8, "label": "v", "properties": {"id": "left rel, end node"}}::vertex
+ {"id": 9, "label": "v", "properties": {"id": "path, initial node"}}::vertex
+ {"id": 10, "label": "v", "properties": {"id": "path, middle node"}}::vertex
+ {"id": 11, "label": "v", "properties": {"id": "path, last node"}}::vertex
+ {"id": 12, "label": "v", "properties": {"id": "divergent, initial node"}}::vertex
+ {"id": 13, "label": "v", "properties": {"id": "divergent middle node"}}::vertex
+ {"id": 14, "label": "v", "properties": {"id": "divergent, end node"}}::vertex
+ {"id": 15, "label": "v", "properties": {"id": "convergent, initial node"}}::vertex
+ {"id": 16, "label": "v", "properties": {"id": "convergent middle node"}}::vertex
+ {"id": 17, "label": "v", "properties": {"id": "convergent, end node"}}::vertex
+ {"id": 18, "label": "v", "properties": {"id": "paths, vertex one"}}::vertex
+ {"id": 19, "label": "v", "properties": {"id": "paths, vertex two"}}::vertex
+ {"id": 20, "label": "v", "properties": {"id": "paths, vertex three"}}::vertex
+ {"id": 21, "label": "v", "properties": {"id": "paths, vertex four"}}::vertex
+ {"id": 22, "label": "n_var", "properties": {"name": "Node A"}}::vertex
+ {"id": 23, "label": "n_var", "properties": {"name": "Node B"}}::vertex
+ {"id": 24, "label": "n_var", "properties": {"name": "Node C"}}::vertex
+ {"id": 25, "label": "n_other_node", "properties": {}}::vertex
+ {"id": 26, "label": "n_other_node", "properties": {}}::vertex
+ {"id": 27, "label": "n_other_node", "properties": {}}::vertex
 (46 rows)
 
 -- prepared statements
 PREPARE p_1 AS SELECT * FROM cypher('cypher_create', $$CREATE (v:new_vertex {key: 'value'}) RETURN v$$) AS (a agtype);
 EXECUTE p_1;
-                                            a                                            
------------------------------------------------------------------------------------------
- {"id": 2533274790395905, "label": "new_vertex", "properties": {"key": "value"}}::vertex
+                                     a                                     
+---------------------------------------------------------------------------
+ {"id": 47, "label": "new_vertex", "properties": {"key": "value"}}::vertex
 (1 row)
 
 EXECUTE p_1;
-                                            a                                            
------------------------------------------------------------------------------------------
- {"id": 2533274790395906, "label": "new_vertex", "properties": {"key": "value"}}::vertex
+                                     a                                     
+---------------------------------------------------------------------------
+ {"id": 48, "label": "new_vertex", "properties": {"key": "value"}}::vertex
 (1 row)
 
 PREPARE p_2 AS SELECT * FROM cypher('cypher_create', $$CREATE (v:new_vertex {key: $var_name}) RETURN v$$, $1) AS (a agtype);
 EXECUTE p_2('{"var_name": "Hello Prepared Statements"}');
-                                                      a                                                      
--------------------------------------------------------------------------------------------------------------
- {"id": 2533274790395907, "label": "new_vertex", "properties": {"key": "Hello Prepared Statements"}}::vertex
+                                               a                                               
+-----------------------------------------------------------------------------------------------
+ {"id": 49, "label": "new_vertex", "properties": {"key": "Hello Prepared Statements"}}::vertex
 (1 row)
 
 EXECUTE p_2('{"var_name": "Hello Prepared Statements 2"}');
-                                                       a                                                       
----------------------------------------------------------------------------------------------------------------
- {"id": 2533274790395908, "label": "new_vertex", "properties": {"key": "Hello Prepared Statements 2"}}::vertex
+                                                a                                                
+-------------------------------------------------------------------------------------------------
+ {"id": 50, "label": "new_vertex", "properties": {"key": "Hello Prepared Statements 2"}}::vertex
 (1 row)
 
 -- pl/pgsql
@@ -478,15 +478,15 @@ BEGIN
 END
 $BODY$;
 SELECT create_test();
-                                       create_test                                       
------------------------------------------------------------------------------------------
- {"id": 2533274790395909, "label": "new_vertex", "properties": {"key": "value"}}::vertex
+                                create_test                                
+---------------------------------------------------------------------------
+ {"id": 51, "label": "new_vertex", "properties": {"key": "value"}}::vertex
 (1 row)
 
 SELECT create_test();
-                                       create_test                                       
------------------------------------------------------------------------------------------
- {"id": 2533274790395910, "label": "new_vertex", "properties": {"key": "value"}}::vertex
+                                create_test                                
+---------------------------------------------------------------------------
+ {"id": 52, "label": "new_vertex", "properties": {"key": "value"}}::vertex
 (1 row)
 
 --
@@ -523,9 +523,9 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE p=(a)
 	RETURN p
 $$) as (a agtype);
-                                   a                                    
-------------------------------------------------------------------------
- [{"id": 281474976710677, "label": "", "properties": {}}::vertex]::path
+                             a                             
+-----------------------------------------------------------
+ [{"id": 53, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --CREATE with joins
@@ -602,9 +602,9 @@ SELECT * FROM cypher('cypher_create', $$ CREATE (a:Part {part_num: '670'}) $$) a
 (0 rows)
 
 SELECT * FROM cypher('cypher_create', $$ MATCH (a:Part) RETURN a $$) as (a agtype);
-                                          a                                           
---------------------------------------------------------------------------------------
- {"id": 3659174697238529, "label": "Part", "properties": {"part_num": "670"}}::vertex
+                                   a                                    
+------------------------------------------------------------------------
+ {"id": 59, "label": "Part", "properties": {"part_num": "670"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$ CREATE (a:Part {part_num: '671'}) $$) as (a agtype);
@@ -618,11 +618,11 @@ SELECT * FROM cypher('cypher_create', $$ CREATE (a:Part {part_num: '672'}) $$) a
 (0 rows)
 
 SELECT * FROM cypher('cypher_create', $$ MATCH (a:Part) RETURN a $$) as (a agtype);
-                                          a                                           
---------------------------------------------------------------------------------------
- {"id": 3659174697238529, "label": "Part", "properties": {"part_num": "670"}}::vertex
- {"id": 3659174697238530, "label": "Part", "properties": {"part_num": "671"}}::vertex
- {"id": 3659174697238531, "label": "Part", "properties": {"part_num": "672"}}::vertex
+                                   a                                    
+------------------------------------------------------------------------
+ {"id": 59, "label": "Part", "properties": {"part_num": "670"}}::vertex
+ {"id": 60, "label": "Part", "properties": {"part_num": "671"}}::vertex
+ {"id": 61, "label": "Part", "properties": {"part_num": "672"}}::vertex
 (3 rows)
 
 SELECT * FROM cypher('cypher_create', $$ CREATE (a:Part {part_num: '673'}) $$) as (a agtype);
@@ -631,12 +631,12 @@ SELECT * FROM cypher('cypher_create', $$ CREATE (a:Part {part_num: '673'}) $$) a
 (0 rows)
 
 SELECT * FROM cypher('cypher_create', $$ MATCH (a:Part) RETURN a $$) as (a agtype);
-                                          a                                           
---------------------------------------------------------------------------------------
- {"id": 3659174697238529, "label": "Part", "properties": {"part_num": "670"}}::vertex
- {"id": 3659174697238530, "label": "Part", "properties": {"part_num": "671"}}::vertex
- {"id": 3659174697238531, "label": "Part", "properties": {"part_num": "672"}}::vertex
- {"id": 3659174697238532, "label": "Part", "properties": {"part_num": "673"}}::vertex
+                                   a                                    
+------------------------------------------------------------------------
+ {"id": 59, "label": "Part", "properties": {"part_num": "670"}}::vertex
+ {"id": 60, "label": "Part", "properties": {"part_num": "671"}}::vertex
+ {"id": 61, "label": "Part", "properties": {"part_num": "672"}}::vertex
+ {"id": 62, "label": "Part", "properties": {"part_num": "673"}}::vertex
 (4 rows)
 
 END;
@@ -648,18 +648,18 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (p)-[a:new]->(p)
 	RETURN p,a,p
 $$) as (n1 agtype, e agtype, n2 agtype);
-                               n1                               |                                                            e                                                             |                               n2                               
-----------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------
- {"id": 281474976710681, "label": "", "properties": {}}::vertex | {"id": 3940649673949185, "label": "new", "end_id": 281474976710681, "start_id": 281474976710681, "properties": {}}::edge | {"id": 281474976710681, "label": "", "properties": {}}::vertex
+                        n1                         |                                        e                                         |                        n2                         
+---------------------------------------------------+----------------------------------------------------------------------------------+---------------------------------------------------
+ {"id": 63, "label": "", "properties": {}}::vertex | {"id": 44, "label": "new", "end_id": 63, "start_id": 63, "properties": {}}::edge | {"id": 63, "label": "", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
 	CREATE (p:node)-[e:new]->(p)
 	RETURN p,e,p
 $$) as (n1 agtype, e agtype, n2 agtype);
-                                 n1                                  |                                                             e                                                              |                                 n2                                  
----------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------
- {"id": 4222124650659841, "label": "node", "properties": {}}::vertex | {"id": 3940649673949186, "label": "new", "end_id": 4222124650659841, "start_id": 4222124650659841, "properties": {}}::edge | {"id": 4222124650659841, "label": "node", "properties": {}}::vertex
+                          n1                           |                                        e                                         |                          n2                           
+-------------------------------------------------------+----------------------------------------------------------------------------------+-------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {}}::vertex | {"id": 45, "label": "new", "end_id": 64, "start_id": 64, "properties": {}}::edge | {"id": 64, "label": "node", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -667,9 +667,9 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (p)-[a:new]->(p)
 	RETURN p,a,p
 $$) as (n1 agtype, e agtype, n2 agtype);
-                               n1                               |                                                            e                                                             |                               n2                               
-----------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------
- {"id": 281474976710682, "label": "", "properties": {}}::vertex | {"id": 3940649673949187, "label": "new", "end_id": 281474976710682, "start_id": 281474976710682, "properties": {}}::edge | {"id": 281474976710682, "label": "", "properties": {}}::vertex
+                        n1                         |                                        e                                         |                        n2                         
+---------------------------------------------------+----------------------------------------------------------------------------------+---------------------------------------------------
+ {"id": 65, "label": "", "properties": {}}::vertex | {"id": 46, "label": "new", "end_id": 65, "start_id": 65, "properties": {}}::edge | {"id": 65, "label": "", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -677,9 +677,9 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (p)-[a:new]->(p)
 	RETURN p,a,p
 $$) as (n1 agtype, e agtype, n2 agtype);
-                                n1                                 |                                                             e                                                              |                                n2                                 
--------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------
- {"id": 4503599627370497, "label": "n1", "properties": {}}::vertex | {"id": 3940649673949188, "label": "new", "end_id": 4503599627370497, "start_id": 4503599627370497, "properties": {}}::edge | {"id": 4503599627370497, "label": "n1", "properties": {}}::vertex
+                         n1                          |                                        e                                         |                         n2                          
+-----------------------------------------------------+----------------------------------------------------------------------------------+-----------------------------------------------------
+ {"id": 66, "label": "n1", "properties": {}}::vertex | {"id": 47, "label": "new", "end_id": 66, "start_id": 66, "properties": {}}::edge | {"id": 66, "label": "n1", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_create', $$
@@ -687,9 +687,9 @@ SELECT * FROM cypher('cypher_create', $$
 	CREATE (p)-[a:new]->(p)
 	RETURN p,a,p
 $$) as (n1 agtype, e agtype, n2 agtype);
-                                 n1                                  |                                                             e                                                              |                                 n2                                  
----------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------
- {"id": 4222124650659841, "label": "node", "properties": {}}::vertex | {"id": 3940649673949189, "label": "new", "end_id": 4222124650659841, "start_id": 4222124650659841, "properties": {}}::edge | {"id": 4222124650659841, "label": "node", "properties": {}}::vertex
+                          n1                           |                                        e                                         |                          n2                           
+-------------------------------------------------------+----------------------------------------------------------------------------------+-------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {}}::vertex | {"id": 48, "label": "new", "end_id": 64, "start_id": 64, "properties": {}}::edge | {"id": 64, "label": "node", "properties": {}}::vertex
 (1 row)
 
 -- Invalid variable reuse
@@ -771,8 +771,10 @@ LINE 3:  CREATE (p)-[e:new]->(a)
 DROP TABLE simple_path;
 DROP FUNCTION create_test;
 SELECT drop_graph('cypher_create', true);
-NOTICE:  drop cascades to 16 other objects
-DETAIL:  drop cascades to table cypher_create._ag_label_vertex
+NOTICE:  drop cascades to 18 other objects
+DETAIL:  drop cascades to sequence cypher_create.vertex_id_seq
+drop cascades to table cypher_create._ag_label_vertex
+drop cascades to sequence cypher_create.edge_id_seq
 drop cascades to table cypher_create._ag_label_edge
 drop cascades to table cypher_create.v
 drop cascades to table cypher_create.e

--- a/regress/expected/cypher_merge.out
+++ b/regress/expected/cypher_merge.out
@@ -39,9 +39,9 @@ SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: "Hello Merge", j: (null IS N
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                                    n                                                    
----------------------------------------------------------------------------------------------------------
- {"id": 281474976710657, "label": "", "properties": {"i": "Hello Merge", "j": true, "k": false}}::vertex
+                                             n                                             
+-------------------------------------------------------------------------------------------
+ {"id": 1, "label": "", "properties": {"i": "Hello Merge", "j": true, "k": false}}::vertex
 (1 row)
 
 --clean up
@@ -72,9 +72,9 @@ SELECT * FROM cypher('cypher_merge', $$MERGE ({j: (null IS NULL)})$$) AS (a agty
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                              n                                              
----------------------------------------------------------------------------------------------
- {"id": 281474976710658, "label": "", "properties": {"i": "Hello Merge", "j": true}}::vertex
+                                       n                                       
+-------------------------------------------------------------------------------
+ {"id": 2, "label": "", "properties": {"i": "Hello Merge", "j": true}}::vertex
 (1 row)
 
 --clean up
@@ -120,9 +120,9 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) MERGE ({i: n.i})$$) AS (a agtyp
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                        n                                         
-----------------------------------------------------------------------------------
- {"id": 281474976710659, "label": "", "properties": {"i": "Hello Merge"}}::vertex
+                                 n                                  
+--------------------------------------------------------------------
+ {"id": 3, "label": "", "properties": {"i": "Hello Merge"}}::vertex
 (1 row)
 
 --clean up
@@ -148,10 +148,10 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) MERGE ({j: n.i})$$) AS (a agtyp
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                        n                                         
-----------------------------------------------------------------------------------
- {"id": 281474976710660, "label": "", "properties": {"i": "Hello Merge"}}::vertex
- {"id": 281474976710661, "label": "", "properties": {"j": "Hello Merge"}}::vertex
+                                 n                                  
+--------------------------------------------------------------------
+ {"id": 4, "label": "", "properties": {"i": "Hello Merge"}}::vertex
+ {"id": 5, "label": "", "properties": {"j": "Hello Merge"}}::vertex
 (2 rows)
 
 --clean up
@@ -171,17 +171,17 @@ SELECT * FROM cypher('cypher_merge', $$CREATE ({i: 2}) $$) AS (a agtype);
 
 --test query
 SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: 1}) RETURN n$$) AS (a agtype);
-                                  a                                   
-----------------------------------------------------------------------
- {"id": 281474976710663, "label": "", "properties": {"i": 1}}::vertex
+                           a                            
+--------------------------------------------------------
+ {"id": 7, "label": "", "properties": {"i": 1}}::vertex
 (1 row)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                  n                                   
-----------------------------------------------------------------------
- {"id": 281474976710662, "label": "", "properties": {"i": 2}}::vertex
- {"id": 281474976710663, "label": "", "properties": {"i": 1}}::vertex
+                           n                            
+--------------------------------------------------------
+ {"id": 6, "label": "", "properties": {"i": 2}}::vertex
+ {"id": 7, "label": "", "properties": {"i": 1}}::vertex
 (2 rows)
 
 --clean up
@@ -216,20 +216,20 @@ SELECT * FROM cypher('cypher_merge', $$CREATE () $$) AS (a agtype);
 
 --test query
 SELECT * FROM cypher('cypher_merge', $$MERGE (n {i: 1}) RETURN n$$) AS (a agtype);
-                                  a                                   
-----------------------------------------------------------------------
- {"id": 281474976710664, "label": "", "properties": {"i": 1}}::vertex
- {"id": 281474976710665, "label": "", "properties": {"i": 1}}::vertex
+                           a                            
+--------------------------------------------------------
+ {"id": 8, "label": "", "properties": {"i": 1}}::vertex
+ {"id": 9, "label": "", "properties": {"i": 1}}::vertex
 (2 rows)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                                  n                                   
-----------------------------------------------------------------------
- {"id": 281474976710664, "label": "", "properties": {"i": 1}}::vertex
- {"id": 281474976710665, "label": "", "properties": {"i": 1}}::vertex
- {"id": 281474976710666, "label": "", "properties": {"i": 2}}::vertex
- {"id": 281474976710667, "label": "", "properties": {}}::vertex
+                            n                            
+---------------------------------------------------------
+ {"id": 8, "label": "", "properties": {"i": 1}}::vertex
+ {"id": 9, "label": "", "properties": {"i": 1}}::vertex
+ {"id": 10, "label": "", "properties": {"i": 2}}::vertex
+ {"id": 11, "label": "", "properties": {}}::vertex
 (4 rows)
 
 --clean up
@@ -258,9 +258,9 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) MERGE (n)-[:e]->(:v)$$) AS (a a
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n)-[e:e]->(m:v) RETURN n, e, m$$) AS (n agtype, e agtype, m agtype);
-                               n                                |                                                           e                                                            |                                m                                 
-----------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- {"id": 281474976710668, "label": "", "properties": {}}::vertex | {"id": 844424930131969, "label": "e", "end_id": 1125899906842625, "start_id": 281474976710668, "properties": {}}::edge | {"id": 1125899906842625, "label": "v", "properties": {}}::vertex
+                         n                         |                                       e                                       |                         m                          
+---------------------------------------------------+-------------------------------------------------------------------------------+----------------------------------------------------
+ {"id": 12, "label": "", "properties": {}}::vertex | {"id": 1, "label": "e", "end_id": 13, "start_id": 12, "properties": {}}::edge | {"id": 13, "label": "v", "properties": {}}::vertex
 (1 row)
 
 --clean up
@@ -286,9 +286,9 @@ SELECT * FROM cypher('cypher_merge', $$MERGE (n)-[:e]->(:v)$$) AS (a agtype);
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (n)-[e:e]->(m:v) RETURN n, e, m$$) AS (n agtype, e agtype, m agtype);
-                               n                                |                                                           e                                                            |                                m                                 
-----------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- {"id": 281474976710671, "label": "", "properties": {}}::vertex | {"id": 844424930131971, "label": "e", "end_id": 1125899906842626, "start_id": 281474976710671, "properties": {}}::edge | {"id": 1125899906842626, "label": "v", "properties": {}}::vertex
+                         n                         |                                       e                                       |                         m                          
+---------------------------------------------------+-------------------------------------------------------------------------------+----------------------------------------------------
+ {"id": 16, "label": "", "properties": {}}::vertex | {"id": 3, "label": "e", "end_id": 17, "start_id": 16, "properties": {}}::edge | {"id": 17, "label": "v", "properties": {}}::vertex
 (1 row)
 
 --clean up
@@ -314,9 +314,9 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) MERGE (n)-[:e]->(:v)$$) AS (a a
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (n)-[e:e]->(m:v) RETURN n, e, m$$) AS (n agtype, e agtype, m agtype);
-                               n                                |                                                           e                                                            |                                m                                 
-----------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- {"id": 281474976710672, "label": "", "properties": {}}::vertex | {"id": 844424930131972, "label": "e", "end_id": 1125899906842627, "start_id": 281474976710672, "properties": {}}::edge | {"id": 1125899906842627, "label": "v", "properties": {}}::vertex
+                         n                         |                                       e                                       |                         m                          
+---------------------------------------------------+-------------------------------------------------------------------------------+----------------------------------------------------
+ {"id": 18, "label": "", "properties": {}}::vertex | {"id": 4, "label": "e", "end_id": 19, "start_id": 18, "properties": {}}::edge | {"id": 19, "label": "v", "properties": {}}::vertex
 (1 row)
 
 --clean up
@@ -342,10 +342,10 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) MERGE (n)-[:e]->(:v)$$) AS (a a
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (n)-[e:e]->(m:v) RETURN n, e, m$$) AS (n agtype, e agtype, m agtype);
-                               n                                |                                                           e                                                            |                                m                                 
-----------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- {"id": 281474976710673, "label": "", "properties": {}}::vertex | {"id": 844424930131974, "label": "e", "end_id": 1125899906842628, "start_id": 281474976710673, "properties": {}}::edge | {"id": 1125899906842628, "label": "v", "properties": {}}::vertex
- {"id": 281474976710674, "label": "", "properties": {}}::vertex | {"id": 844424930131975, "label": "e", "end_id": 1125899906842629, "start_id": 281474976710674, "properties": {}}::edge | {"id": 1125899906842629, "label": "v", "properties": {}}::vertex
+                         n                         |                                       e                                       |                         m                          
+---------------------------------------------------+-------------------------------------------------------------------------------+----------------------------------------------------
+ {"id": 20, "label": "", "properties": {}}::vertex | {"id": 6, "label": "e", "end_id": 22, "start_id": 20, "properties": {}}::edge | {"id": 22, "label": "v", "properties": {}}::vertex
+ {"id": 21, "label": "", "properties": {}}::vertex | {"id": 7, "label": "e", "end_id": 23, "start_id": 21, "properties": {}}::edge | {"id": 23, "label": "v", "properties": {}}::vertex
 (2 rows)
 
 --clean up
@@ -414,10 +414,10 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) MERGE (n)-[:e_new]->(:v)$$) AS 
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (n)-[e]->(m:v) RETURN n, e, m$$) AS (n agtype, e agtype, m agtype);
-                               n                                |                                                              e                                                              |                                m                                 
-----------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- {"id": 281474976710680, "label": "", "properties": {}}::vertex | {"id": 1407374883553281, "label": "e_new", "end_id": 1125899906842630, "start_id": 281474976710680, "properties": {}}::edge | {"id": 1125899906842630, "label": "v", "properties": {}}::vertex
- {"id": 281474976710681, "label": "", "properties": {}}::vertex | {"id": 1407374883553282, "label": "e_new", "end_id": 1125899906842631, "start_id": 281474976710681, "properties": {}}::edge | {"id": 1125899906842631, "label": "v", "properties": {}}::vertex
+                         n                         |                                         e                                          |                         m                          
+---------------------------------------------------+------------------------------------------------------------------------------------+----------------------------------------------------
+ {"id": 29, "label": "", "properties": {}}::vertex | {"id": 12, "label": "e_new", "end_id": 31, "start_id": 29, "properties": {}}::edge | {"id": 31, "label": "v", "properties": {}}::vertex
+ {"id": 30, "label": "", "properties": {}}::vertex | {"id": 13, "label": "e_new", "end_id": 32, "start_id": 30, "properties": {}}::edge | {"id": 32, "label": "v", "properties": {}}::vertex
 (2 rows)
 
 --clean up
@@ -443,9 +443,9 @@ SELECT * FROM cypher('cypher_merge', $$MERGE (n)-[:e_new]->(:v)$$) AS (a agtype)
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (n)-[e]->(m:v) RETURN n, e, m$$) AS (n agtype, e agtype, m agtype);
-                               n                                |                                                              e                                                              |                                m                                 
-----------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- {"id": 281474976710684, "label": "", "properties": {}}::vertex | {"id": 1407374883553283, "label": "e_new", "end_id": 1125899906842632, "start_id": 281474976710684, "properties": {}}::edge | {"id": 1125899906842632, "label": "v", "properties": {}}::vertex
+                         n                         |                                         e                                          |                         m                          
+---------------------------------------------------+------------------------------------------------------------------------------------+----------------------------------------------------
+ {"id": 35, "label": "", "properties": {}}::vertex | {"id": 15, "label": "e_new", "end_id": 36, "start_id": 35, "properties": {}}::edge | {"id": 36, "label": "v", "properties": {}}::vertex
 (1 row)
 
 --clean up
@@ -468,9 +468,9 @@ SELECT * FROM cypher('cypher_merge', $$CREATE () MERGE (n)$$) AS (a agtype);
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (n agtype);
-                               n                                
-----------------------------------------------------------------
- {"id": 281474976710685, "label": "", "properties": {}}::vertex
+                         n                         
+---------------------------------------------------
+ {"id": 37, "label": "", "properties": {}}::vertex
 (1 row)
 
 --clean up
@@ -490,9 +490,9 @@ SELECT * FROM cypher('cypher_merge', $$CREATE (n) WITH n as a MERGE (a)-[:e]->()
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH p=()-[:e]->() RETURN p$$) AS (p agtype);
-                                                                                                                               p                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710687, "label": "", "properties": {}}::vertex, {"id": 844424930131981, "label": "e", "end_id": 281474976710688, "start_id": 281474976710687, "properties": {}}::edge, {"id": 281474976710688, "label": "", "properties": {}}::vertex]::path
+                                                                                              p                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 39, "label": "", "properties": {}}::vertex, {"id": 16, "label": "e", "end_id": 40, "start_id": 39, "properties": {}}::edge, {"id": 40, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --clean up
@@ -512,9 +512,9 @@ SELECT * FROM cypher('cypher_merge', $$CREATE (n) MERGE (n)-[:e]->() $$) AS (a a
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH p=()-[:e]->() RETURN p$$) AS (p agtype);
-                                                                                                                               p                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710689, "label": "", "properties": {}}::vertex, {"id": 844424930131982, "label": "e", "end_id": 281474976710690, "start_id": 281474976710689, "properties": {}}::edge, {"id": 281474976710690, "label": "", "properties": {}}::vertex]::path
+                                                                                              p                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 41, "label": "", "properties": {}}::vertex, {"id": 17, "label": "e", "end_id": 42, "start_id": 41, "properties": {}}::edge, {"id": 42, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --clean up
@@ -534,9 +534,9 @@ SELECT * FROM cypher('cypher_merge', $$CREATE (n {i : 1}) SET n.i = 2 MERGE ({i:
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (a) RETURN a$$) AS (a agtype);
-                                  a                                   
-----------------------------------------------------------------------
- {"id": 281474976710691, "label": "", "properties": {"i": 2}}::vertex
+                            a                            
+---------------------------------------------------------
+ {"id": 43, "label": "", "properties": {"i": 2}}::vertex
 (1 row)
 
 --clean up
@@ -556,9 +556,9 @@ SELECT * FROM cypher('cypher_merge', $$CREATE (n {i : 1}) SET n.i = 2 WITH n as 
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (a) RETURN a$$) AS (a agtype);
-                                  a                                   
-----------------------------------------------------------------------
- {"id": 281474976710692, "label": "", "properties": {"i": 2}}::vertex
+                            a                            
+---------------------------------------------------------
+ {"id": 44, "label": "", "properties": {"i": 2}}::vertex
 (1 row)
 
 --clean up
@@ -584,9 +584,9 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n {i : 1}) SET n.i = 2 WITH n as a
 
 --validate created correctly
 SELECT * FROM cypher('cypher_merge', $$MATCH (a) RETURN a$$) AS (a agtype);
-                                  a                                   
-----------------------------------------------------------------------
- {"id": 281474976710693, "label": "", "properties": {"i": 2}}::vertex
+                            a                            
+---------------------------------------------------------
+ {"id": 45, "label": "", "properties": {"i": 2}}::vertex
 (1 row)
 
 --clean up
@@ -609,9 +609,9 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n {i : 1}) DELETE n  MERGE (n)-[:e
 ERROR:  vertex assigned to variable n was deleted
 --validate, transaction was rolled back because of the error message
 SELECT * FROM cypher('cypher_merge', $$MATCH (a) RETURN a$$) AS (a agtype);
-                                  a                                   
-----------------------------------------------------------------------
- {"id": 281474976710694, "label": "", "properties": {"i": 1}}::vertex
+                            a                            
+---------------------------------------------------------
+ {"id": 46, "label": "", "properties": {"i": 1}}::vertex
 (1 row)
 
 --clean up
@@ -652,23 +652,23 @@ SELECT * FROM cypher('cypher_merge', $$
     MERGE (person)-[r:BORN_IN]->(city)
     RETURN person.name, person.bornIn, city
 $$) AS (name agtype, bornIn agtype, city agtype);
-       name        |    bornin    |                                          city                                           
--------------------+--------------+-----------------------------------------------------------------------------------------
- "Rob Reiner"      | "New York"   | {"id": 1970324836974593, "label": "City", "properties": {"name": "New York"}}::vertex
- "Martin Sheen"    | "Ohio"       | {"id": 1970324836974595, "label": "City", "properties": {"name": "Ohio"}}::vertex
- "Michael Douglas" | "New Jersey" | {"id": 1970324836974594, "label": "City", "properties": {"name": "New Jersey"}}::vertex
+       name        |    bornin    |                                   city                                    
+-------------------+--------------+---------------------------------------------------------------------------
+ "Rob Reiner"      | "New York"   | {"id": 50, "label": "City", "properties": {"name": "New York"}}::vertex
+ "Michael Douglas" | "New Jersey" | {"id": 51, "label": "City", "properties": {"name": "New Jersey"}}::vertex
+ "Martin Sheen"    | "Ohio"       | {"id": 52, "label": "City", "properties": {"name": "Ohio"}}::vertex
 (3 rows)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (a) RETURN a$$) AS (a agtype);
-                                                           a                                                            
-------------------------------------------------------------------------------------------------------------------------
- {"id": 1688849860263937, "label": "Person", "properties": {"name": "Rob Reiner", "bornIn": "New York"}}::vertex
- {"id": 1688849860263938, "label": "Person", "properties": {"name": "Michael Douglas", "bornIn": "New Jersey"}}::vertex
- {"id": 1688849860263939, "label": "Person", "properties": {"name": "Martin Sheen", "bornIn": "Ohio"}}::vertex
- {"id": 1970324836974593, "label": "City", "properties": {"name": "New York"}}::vertex
- {"id": 1970324836974594, "label": "City", "properties": {"name": "New Jersey"}}::vertex
- {"id": 1970324836974595, "label": "City", "properties": {"name": "Ohio"}}::vertex
+                                                    a                                                     
+----------------------------------------------------------------------------------------------------------
+ {"id": 47, "label": "Person", "properties": {"name": "Rob Reiner", "bornIn": "New York"}}::vertex
+ {"id": 48, "label": "Person", "properties": {"name": "Michael Douglas", "bornIn": "New Jersey"}}::vertex
+ {"id": 49, "label": "Person", "properties": {"name": "Martin Sheen", "bornIn": "Ohio"}}::vertex
+ {"id": 50, "label": "City", "properties": {"name": "New York"}}::vertex
+ {"id": 51, "label": "City", "properties": {"name": "New Jersey"}}::vertex
+ {"id": 52, "label": "City", "properties": {"name": "Ohio"}}::vertex
 (6 rows)
 
 --clean up
@@ -687,9 +687,9 @@ SELECT * FROM cypher('cypher_merge', $$MERGE ()-[:e]-()$$) AS (a agtype);
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH p=()-[]->() RETURN p$$) AS (a agtype);
-                                                                                                                               a                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710695, "label": "", "properties": {}}::vertex, {"id": 844424930131983, "label": "e", "end_id": 281474976710696, "start_id": 281474976710695, "properties": {}}::edge, {"id": 281474976710696, "label": "", "properties": {}}::vertex]::path
+                                                                                              a                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 53, "label": "", "properties": {}}::vertex, {"id": 21, "label": "e", "end_id": 54, "start_id": 53, "properties": {}}::edge, {"id": 54, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --clean up
@@ -702,16 +702,16 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * test 24:
  */
 SELECT * FROM cypher('cypher_merge', $$MERGE (a) RETURN a$$) AS (a agtype);
-                               a                                
-----------------------------------------------------------------
- {"id": 281474976710697, "label": "", "properties": {}}::vertex
+                         a                         
+---------------------------------------------------
+ {"id": 55, "label": "", "properties": {}}::vertex
 (1 row)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH (a) RETURN a$$) AS (a agtype);
-                               a                                
-----------------------------------------------------------------
- {"id": 281474976710697, "label": "", "properties": {}}::vertex
+                         a                         
+---------------------------------------------------
+ {"id": 55, "label": "", "properties": {}}::vertex
 (1 row)
 
 --clean up
@@ -724,16 +724,16 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * test 25:
  */
 SELECT * FROM cypher('cypher_merge', $$MERGE p=()-[:e]-() RETURN p$$) AS (a agtype);
-                                                                                                                               a                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710698, "label": "", "properties": {}}::vertex, {"id": 844424930131984, "label": "e", "end_id": 281474976710699, "start_id": 281474976710698, "properties": {}}::edge, {"id": 281474976710699, "label": "", "properties": {}}::vertex]::path
+                                                                                              a                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 56, "label": "", "properties": {}}::vertex, {"id": 22, "label": "e", "end_id": 57, "start_id": 56, "properties": {}}::edge, {"id": 57, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH p=()-[]->() RETURN p$$) AS (a agtype);
-                                                                                                                               a                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710698, "label": "", "properties": {}}::vertex, {"id": 844424930131984, "label": "e", "end_id": 281474976710699, "start_id": 281474976710698, "properties": {}}::edge, {"id": 281474976710699, "label": "", "properties": {}}::vertex]::path
+                                                                                              a                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 56, "label": "", "properties": {}}::vertex, {"id": 22, "label": "e", "end_id": 57, "start_id": 56, "properties": {}}::edge, {"id": 57, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --clean up
@@ -746,16 +746,16 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * test 26:
  */
 SELECT * FROM cypher('cypher_merge', $$MERGE (a)-[:e]-(b) RETURN a$$) AS (a agtype);
-                               a                                
-----------------------------------------------------------------
- {"id": 281474976710700, "label": "", "properties": {}}::vertex
+                         a                         
+---------------------------------------------------
+ {"id": 58, "label": "", "properties": {}}::vertex
 (1 row)
 
 --validate
 SELECT * FROM cypher('cypher_merge', $$MATCH p=()-[]->() RETURN p$$) AS (a agtype);
-                                                                                                                               a                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710700, "label": "", "properties": {}}::vertex, {"id": 844424930131985, "label": "e", "end_id": 281474976710701, "start_id": 281474976710700, "properties": {}}::edge, {"id": 281474976710701, "label": "", "properties": {}}::vertex]::path
+                                                                                              a                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 58, "label": "", "properties": {}}::vertex, {"id": 23, "label": "e", "end_id": 59, "start_id": 58, "properties": {}}::edge, {"id": 59, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 --clean up
@@ -768,16 +768,16 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * test 27:
  */
 SELECT  * FROM cypher('cypher_merge', $$CREATE p=()-[:e]->() RETURN p$$) AS (a agtype);
-                                                                                                                               a                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710702, "label": "", "properties": {}}::vertex, {"id": 844424930131986, "label": "e", "end_id": 281474976710703, "start_id": 281474976710702, "properties": {}}::edge, {"id": 281474976710703, "label": "", "properties": {}}::vertex]::path
+                                                                                              a                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 60, "label": "", "properties": {}}::vertex, {"id": 24, "label": "e", "end_id": 61, "start_id": 60, "properties": {}}::edge, {"id": 61, "label": "", "properties": {}}::vertex]::path
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$MERGE p=()-[:e]-() RETURN p$$) AS (a agtype);
-                                                                                                                               a                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710702, "label": "", "properties": {}}::vertex, {"id": 844424930131986, "label": "e", "end_id": 281474976710703, "start_id": 281474976710702, "properties": {}}::edge, {"id": 281474976710703, "label": "", "properties": {}}::vertex]::path
- [{"id": 281474976710703, "label": "", "properties": {}}::vertex, {"id": 844424930131986, "label": "e", "end_id": 281474976710703, "start_id": 281474976710702, "properties": {}}::edge, {"id": 281474976710702, "label": "", "properties": {}}::vertex]::path
+                                                                                              a                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 60, "label": "", "properties": {}}::vertex, {"id": 24, "label": "e", "end_id": 61, "start_id": 60, "properties": {}}::edge, {"id": 61, "label": "", "properties": {}}::vertex]::path
+ [{"id": 61, "label": "", "properties": {}}::vertex, {"id": 24, "label": "e", "end_id": 61, "start_id": 60, "properties": {}}::edge, {"id": 60, "label": "", "properties": {}}::vertex]::path
 (2 rows)
 
 --clean up
@@ -820,36 +820,36 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) OPTIONAL MATCH (n)-[:e]->(m) ME
 ERROR:  Existing variable m cannot be NULL in MERGE clause
 -- validate only 1 vertex exits
 SELECT * FROM cypher('cypher_merge', $$MATCH (n) RETURN n$$) AS (a agtype);
-                               a                                
-----------------------------------------------------------------
- {"id": 281474976710704, "label": "", "properties": {}}::vertex
+                         a                         
+---------------------------------------------------
+ {"id": 62, "label": "", "properties": {}}::vertex
 (1 row)
 
 --
 -- MERGE/SET test
 -- Node does exist, then set (github issue #235)
 SELECT * FROM cypher('cypher_merge', $$ CREATE (n:node {name: 'Jason'}) RETURN n $$) AS (n agtype);
-                                         n                                          
-------------------------------------------------------------------------------------
- {"id": 2533274790395905, "label": "node", "properties": {"name": "Jason"}}::vertex
+                                  n                                   
+----------------------------------------------------------------------
+ {"id": 63, "label": "node", "properties": {"name": "Jason"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH (n:node) RETURN n $$) AS (n agtype);
-                                         n                                          
-------------------------------------------------------------------------------------
- {"id": 2533274790395905, "label": "node", "properties": {"name": "Jason"}}::vertex
+                                  n                                   
+----------------------------------------------------------------------
+ {"id": 63, "label": "node", "properties": {"name": "Jason"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE (n:node {name: 'Jason'}) SET n.name = 'Lisa' RETURN n $$) AS (n agtype);
-                                         n                                         
------------------------------------------------------------------------------------
- {"id": 2533274790395905, "label": "node", "properties": {"name": "Lisa"}}::vertex
+                                  n                                  
+---------------------------------------------------------------------
+ {"id": 63, "label": "node", "properties": {"name": "Lisa"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH (n:node) RETURN n $$) AS (n agtype);
-                                         n                                         
------------------------------------------------------------------------------------
- {"id": 2533274790395905, "label": "node", "properties": {"name": "Lisa"}}::vertex
+                                  n                                  
+---------------------------------------------------------------------
+ {"id": 63, "label": "node", "properties": {"name": "Lisa"}}::vertex
 (1 row)
 
 -- Node doesn't exist, is created, then set
@@ -864,41 +864,41 @@ SELECT * FROM cypher('cypher_merge', $$ MATCH (n:node) RETURN n $$) AS (n agtype
 (0 rows)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE (n:node {name: 'Jason'}) SET n.name = 'Lisa' RETURN n $$) AS (n agtype);
-                                         n                                         
------------------------------------------------------------------------------------
- {"id": 2533274790395906, "label": "node", "properties": {"name": "Lisa"}}::vertex
+                                  n                                  
+---------------------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {"name": "Lisa"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH (n:node) RETURN n $$) AS (n agtype);
-                                         n                                         
------------------------------------------------------------------------------------
- {"id": 2533274790395906, "label": "node", "properties": {"name": "Lisa"}}::vertex
+                                  n                                  
+---------------------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {"name": "Lisa"}}::vertex
 (1 row)
 
 -- Multiple SETs
 SELECT * FROM cypher('cypher_merge', $$ MERGE (n:node {name: 'Lisa'}) SET n.age = 23, n.gender = "Female" RETURN n $$) AS (n agtype);
-                                                        n                                                         
-------------------------------------------------------------------------------------------------------------------
- {"id": 2533274790395906, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
+                                                 n                                                  
+----------------------------------------------------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH (n:node) RETURN n $$) AS (n agtype);
-                                                        n                                                         
-------------------------------------------------------------------------------------------------------------------
- {"id": 2533274790395906, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
+                                                 n                                                  
+----------------------------------------------------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE (n:node {name: 'Jason'}) SET n.name = 'Lisa', n.age = 23, n.gender = 'Female' RETURN n $$) AS (n agtype);
-                                                        n                                                         
-------------------------------------------------------------------------------------------------------------------
- {"id": 2533274790395907, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
+                                                 n                                                  
+----------------------------------------------------------------------------------------------------
+ {"id": 65, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH (n:node) RETURN n $$) AS (n agtype);
-                                                        n                                                         
-------------------------------------------------------------------------------------------------------------------
- {"id": 2533274790395906, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
- {"id": 2533274790395907, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
+                                                 n                                                  
+----------------------------------------------------------------------------------------------------
+ {"id": 64, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
+ {"id": 65, "label": "node", "properties": {"age": 23, "name": "Lisa", "gender": "Female"}}::vertex
 (2 rows)
 
 --
@@ -911,9 +911,9 @@ SELECT * FROM cypher('cypher_merge', $$ MERGE ()-[:B]->(x:C)-[:E]->(x:C)<-[f:F]-
 (0 rows)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE ()-[:B]->(x:C)-[:E]->(x:C)<-[f:F]-(y:I) RETURN x $$) AS (x agtype);
-                                x                                 
-------------------------------------------------------------------
- {"id": 3096224743817217, "label": "C", "properties": {}}::vertex
+                         x                          
+----------------------------------------------------
+ {"id": 67, "label": "C", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=()-[:B]->(x:C)-[:E]->(x:C)<-[f:F]-(y:I) $$) AS (p agtype);
@@ -922,22 +922,22 @@ SELECT * FROM cypher('cypher_merge', $$ MERGE p=()-[:B]->(x:C)-[:E]->(x:C)<-[f:F
 (0 rows)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=()-[:B]->(x:C)-[:E]->(x:C)<-[f:F]-(y:I) RETURN p $$) AS (p agtype);
-                                                                                                                                                                                                                                                                                                                             p                                                                                                                                                                                                                                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710705, "label": "", "properties": {}}::vertex, {"id": 2814749767106561, "label": "B", "end_id": 3096224743817217, "start_id": 281474976710705, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3377699720527873, "label": "E", "end_id": 3096224743817217, "start_id": 3096224743817217, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3659174697238529, "label": "F", "end_id": 3096224743817217, "start_id": 3940649673949185, "properties": {}}::edge, {"id": 3940649673949185, "label": "I", "properties": {}}::vertex]::path
+                                                                                                                                                                                                                                   p                                                                                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 66, "label": "", "properties": {}}::vertex, {"id": 27, "label": "B", "end_id": 67, "start_id": 66, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex, {"id": 26, "label": "E", "end_id": 67, "start_id": 67, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex, {"id": 25, "label": "F", "end_id": 67, "start_id": 68, "properties": {}}::edge, {"id": 68, "label": "I", "properties": {}}::vertex]::path
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=()-[:B]->(x:C)-[:E]->(x:C)<-[f:F]-(y:I) RETURN p $$) AS (p agtype);
-                                                                                                                                                                                                                                                                                                                             p                                                                                                                                                                                                                                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710705, "label": "", "properties": {}}::vertex, {"id": 2814749767106561, "label": "B", "end_id": 3096224743817217, "start_id": 281474976710705, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3377699720527873, "label": "E", "end_id": 3096224743817217, "start_id": 3096224743817217, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3659174697238529, "label": "F", "end_id": 3096224743817217, "start_id": 3940649673949185, "properties": {}}::edge, {"id": 3940649673949185, "label": "I", "properties": {}}::vertex]::path
+                                                                                                                                                                                                                                   p                                                                                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 66, "label": "", "properties": {}}::vertex, {"id": 27, "label": "B", "end_id": 67, "start_id": 66, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex, {"id": 26, "label": "E", "end_id": 67, "start_id": 67, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex, {"id": 25, "label": "F", "end_id": 67, "start_id": 68, "properties": {}}::edge, {"id": 68, "label": "I", "properties": {}}::vertex]::path
 (1 row)
 
 -- This should only return 1 row, as the path should already exist.
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=()-[:B]->(:C)-[:E]->(:C)<-[:F]-(:I) RETURN p $$) AS (p agtype);
-                                                                                                                                                                                                                                                                                                                             p                                                                                                                                                                                                                                                                                                                             
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- [{"id": 281474976710705, "label": "", "properties": {}}::vertex, {"id": 2814749767106561, "label": "B", "end_id": 3096224743817217, "start_id": 281474976710705, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3377699720527873, "label": "E", "end_id": 3096224743817217, "start_id": 3096224743817217, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3659174697238529, "label": "F", "end_id": 3096224743817217, "start_id": 3940649673949185, "properties": {}}::edge, {"id": 3940649673949185, "label": "I", "properties": {}}::vertex]::path
+                                                                                                                                                                                                                                   p                                                                                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 66, "label": "", "properties": {}}::vertex, {"id": 27, "label": "B", "end_id": 67, "start_id": 66, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex, {"id": 26, "label": "E", "end_id": 67, "start_id": 67, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex, {"id": 25, "label": "F", "end_id": 67, "start_id": 68, "properties": {}}::edge, {"id": 68, "label": "I", "properties": {}}::vertex]::path
 (1 row)
 
 -- test variable reuse in MERGE - the first MERGE of each group should create,
@@ -958,9 +958,9 @@ SELECT * FROM cypher('cypher_merge', $$ MERGE (x:P)-[:E]->(x) $$) AS (x agtype);
 (0 rows)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x:P)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                  p                                                                                                                                   |                                x                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- [{"id": 4222124650659841, "label": "P", "properties": {}}::vertex, {"id": 3377699720527874, "label": "E", "end_id": 4222124650659841, "start_id": 4222124650659841, "properties": {}}::edge, {"id": 4222124650659841, "label": "P", "properties": {}}::vertex]::path | {"id": 4222124650659841, "label": "P", "properties": {}}::vertex
+                                                                                               p                                                                                                |                         x                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------
+ [{"id": 69, "label": "P", "properties": {}}::vertex, {"id": 28, "label": "E", "end_id": 69, "start_id": 69, "properties": {}}::edge, {"id": 69, "label": "P", "properties": {}}::vertex]::path | {"id": 69, "label": "P", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x:Q)-[:E]->(x:Q) RETURN p, x $$) AS (p agtype, x agtype);
@@ -979,9 +979,9 @@ SELECT * FROM cypher('cypher_merge', $$ MERGE (x:Q)-[:E]->(x:Q) $$) AS (x agtype
 (0 rows)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x:Q)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                  p                                                                                                                                   |                                x                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- [{"id": 4503599627370497, "label": "Q", "properties": {}}::vertex, {"id": 3377699720527875, "label": "E", "end_id": 4503599627370497, "start_id": 4503599627370497, "properties": {}}::edge, {"id": 4503599627370497, "label": "Q", "properties": {}}::vertex]::path | {"id": 4503599627370497, "label": "Q", "properties": {}}::vertex
+                                                                                               p                                                                                                |                         x                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------
+ [{"id": 70, "label": "Q", "properties": {}}::vertex, {"id": 29, "label": "E", "end_id": 70, "start_id": 70, "properties": {}}::edge, {"id": 70, "label": "Q", "properties": {}}::vertex]::path | {"id": 70, "label": "Q", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x:R)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
@@ -990,44 +990,44 @@ SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x:R)-[:E]->(x) RETURN p, x $$) 
 (0 rows)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=(x:R)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                  p                                                                                                                                   |                                x                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- [{"id": 4785074604081153, "label": "R", "properties": {}}::vertex, {"id": 3377699720527876, "label": "E", "end_id": 4785074604081153, "start_id": 4785074604081153, "properties": {}}::edge, {"id": 4785074604081153, "label": "R", "properties": {}}::vertex]::path | {"id": 4785074604081153, "label": "R", "properties": {}}::vertex
+                                                                                               p                                                                                                |                         x                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------
+ [{"id": 71, "label": "R", "properties": {}}::vertex, {"id": 30, "label": "E", "end_id": 71, "start_id": 71, "properties": {}}::edge, {"id": 71, "label": "R", "properties": {}}::vertex]::path | {"id": 71, "label": "R", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=(x:R)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                  p                                                                                                                                   |                                x                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- [{"id": 4785074604081153, "label": "R", "properties": {}}::vertex, {"id": 3377699720527876, "label": "E", "end_id": 4785074604081153, "start_id": 4785074604081153, "properties": {}}::edge, {"id": 4785074604081153, "label": "R", "properties": {}}::vertex]::path | {"id": 4785074604081153, "label": "R", "properties": {}}::vertex
+                                                                                               p                                                                                                |                         x                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------
+ [{"id": 71, "label": "R", "properties": {}}::vertex, {"id": 30, "label": "E", "end_id": 71, "start_id": 71, "properties": {}}::edge, {"id": 71, "label": "R", "properties": {}}::vertex]::path | {"id": 71, "label": "R", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x:R)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                  p                                                                                                                                   |                                x                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- [{"id": 4785074604081153, "label": "R", "properties": {}}::vertex, {"id": 3377699720527876, "label": "E", "end_id": 4785074604081153, "start_id": 4785074604081153, "properties": {}}::edge, {"id": 4785074604081153, "label": "R", "properties": {}}::vertex]::path | {"id": 4785074604081153, "label": "R", "properties": {}}::vertex
+                                                                                               p                                                                                                |                         x                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------
+ [{"id": 71, "label": "R", "properties": {}}::vertex, {"id": 30, "label": "E", "end_id": 71, "start_id": 71, "properties": {}}::edge, {"id": 71, "label": "R", "properties": {}}::vertex]::path | {"id": 71, "label": "R", "properties": {}}::vertex
 (1 row)
 
 -- should return 4 rows
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=(x)-[:E]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                  p                                                                                                                                   |                                x                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------
- [{"id": 3096224743817217, "label": "C", "properties": {}}::vertex, {"id": 3377699720527873, "label": "E", "end_id": 3096224743817217, "start_id": 3096224743817217, "properties": {}}::edge, {"id": 3096224743817217, "label": "C", "properties": {}}::vertex]::path | {"id": 3096224743817217, "label": "C", "properties": {}}::vertex
- [{"id": 4222124650659841, "label": "P", "properties": {}}::vertex, {"id": 3377699720527874, "label": "E", "end_id": 4222124650659841, "start_id": 4222124650659841, "properties": {}}::edge, {"id": 4222124650659841, "label": "P", "properties": {}}::vertex]::path | {"id": 4222124650659841, "label": "P", "properties": {}}::vertex
- [{"id": 4503599627370497, "label": "Q", "properties": {}}::vertex, {"id": 3377699720527875, "label": "E", "end_id": 4503599627370497, "start_id": 4503599627370497, "properties": {}}::edge, {"id": 4503599627370497, "label": "Q", "properties": {}}::vertex]::path | {"id": 4503599627370497, "label": "Q", "properties": {}}::vertex
- [{"id": 4785074604081153, "label": "R", "properties": {}}::vertex, {"id": 3377699720527876, "label": "E", "end_id": 4785074604081153, "start_id": 4785074604081153, "properties": {}}::edge, {"id": 4785074604081153, "label": "R", "properties": {}}::vertex]::path | {"id": 4785074604081153, "label": "R", "properties": {}}::vertex
+                                                                                               p                                                                                                |                         x                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------
+ [{"id": 67, "label": "C", "properties": {}}::vertex, {"id": 26, "label": "E", "end_id": 67, "start_id": 67, "properties": {}}::edge, {"id": 67, "label": "C", "properties": {}}::vertex]::path | {"id": 67, "label": "C", "properties": {}}::vertex
+ [{"id": 69, "label": "P", "properties": {}}::vertex, {"id": 28, "label": "E", "end_id": 69, "start_id": 69, "properties": {}}::edge, {"id": 69, "label": "P", "properties": {}}::vertex]::path | {"id": 69, "label": "P", "properties": {}}::vertex
+ [{"id": 70, "label": "Q", "properties": {}}::vertex, {"id": 29, "label": "E", "end_id": 70, "start_id": 70, "properties": {}}::edge, {"id": 70, "label": "Q", "properties": {}}::vertex]::path | {"id": 70, "label": "Q", "properties": {}}::vertex
+ [{"id": 71, "label": "R", "properties": {}}::vertex, {"id": 30, "label": "E", "end_id": 71, "start_id": 71, "properties": {}}::edge, {"id": 71, "label": "R", "properties": {}}::vertex]::path | {"id": 71, "label": "R", "properties": {}}::vertex
 (4 rows)
 
 -- should create 1 row
 SELECT * FROM cypher('cypher_merge', $$ MERGE p=(x)-[:E1]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                p                                                                                                                                |                               x                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------
- [{"id": 281474976710706, "label": "", "properties": {}}::vertex, {"id": 5066549580791809, "label": "E1", "end_id": 281474976710706, "start_id": 281474976710706, "properties": {}}::edge, {"id": 281474976710706, "label": "", "properties": {}}::vertex]::path | {"id": 281474976710706, "label": "", "properties": {}}::vertex
+                                                                                               p                                                                                               |                         x                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------
+ [{"id": 72, "label": "", "properties": {}}::vertex, {"id": 31, "label": "E1", "end_id": 72, "start_id": 72, "properties": {}}::edge, {"id": 72, "label": "", "properties": {}}::vertex]::path | {"id": 72, "label": "", "properties": {}}::vertex
 (1 row)
 
 SELECT * FROM cypher('cypher_merge', $$ MATCH p=(x)-[:E1]->(x) RETURN p, x $$) AS (p agtype, x agtype);
-                                                                                                                                p                                                                                                                                |                               x                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------
- [{"id": 281474976710706, "label": "", "properties": {}}::vertex, {"id": 5066549580791809, "label": "E1", "end_id": 281474976710706, "start_id": 281474976710706, "properties": {}}::edge, {"id": 281474976710706, "label": "", "properties": {}}::vertex]::path | {"id": 281474976710706, "label": "", "properties": {}}::vertex
+                                                                                               p                                                                                               |                         x                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------
+ [{"id": 72, "label": "", "properties": {}}::vertex, {"id": 31, "label": "E1", "end_id": 72, "start_id": 72, "properties": {}}::edge, {"id": 72, "label": "", "properties": {}}::vertex]::path | {"id": 72, "label": "", "properties": {}}::vertex
 (1 row)
 
 -- the following should fail due to multiple labels
@@ -1082,8 +1082,10 @@ SELECT * FROM cypher('cypher_merge', $$MATCH (n) DETACH DELETE n $$) AS (a agtyp
  * Clean up graph
  */
 SELECT drop_graph('cypher_merge', true);
-NOTICE:  drop cascades to 18 other objects
-DETAIL:  drop cascades to table cypher_merge._ag_label_vertex
+NOTICE:  drop cascades to 20 other objects
+DETAIL:  drop cascades to sequence cypher_merge.vertex_id_seq
+drop cascades to table cypher_merge._ag_label_vertex
+drop cascades to sequence cypher_merge.edge_id_seq
 drop cascades to table cypher_merge._ag_label_edge
 drop cascades to table cypher_merge.e
 drop cascades to table cypher_merge.v

--- a/regress/expected/label_redesign_wendel.out
+++ b/regress/expected/label_redesign_wendel.out
@@ -1,0 +1,59 @@
+--
+-- NOTE: TESTS IN THESE FILE WILL BE MOVED TO EXISTING TEST FILES ONCE THEY ARE UPDATED.
+--
+LOAD 'age'; SET search_path TO ag_catalog;
+--
+-- Tests entity_exists function and get_label_id_from_entity
+--
+SELECT create_graph('graph1');
+NOTICE:  graph "graph1" has been created
+ create_graph 
+--------------
+ 
+(1 row)
+
+SELECT * FROM cypher('graph1', $$ CREATE (:Developer{name:'Brian'}) $$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+-- get_label_id_from_entity from set clause
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) SET x.yearOfBirth = 1982, x.surname = 'Jones' RETURN x $$) AS (vertex agtype);
+                                                      vertex                                                       
+-------------------------------------------------------------------------------------------------------------------
+ {"id": 1, "label": "Developer", "properties": {"name": "Brian", "surname": "Jones", "yearOfBirth": 1982}}::vertex
+(1 row)
+
+-- entity_exists returning false
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) DELETE (x) CREATE p=(x)-[r:PARTICIPATES{from:2023}]->(y:Project{title:'Documentation'}) RETURN p $$) AS (path agtype);
+ERROR:  vertex assigned to variable x was deleted
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) DELETE (x) MERGE p=(x)-[r:PARTICIPATES{from:2023}]->(y:Project{title:'Documentation'}) RETURN p $$) AS (path agtype);
+ERROR:  vertex assigned to variable x was deleted
+-- entity_exists returning true
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) CREATE p=(x)-[r:PARTICIPATES{from:2021}]->(y:Project{title:'Dashboard'}) RETURN p $$) AS (path agtype);
+                                                                                                                                                    path                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 1, "label": "Developer", "properties": {"name": "Brian", "surname": "Jones", "yearOfBirth": 1982}}::vertex, {"id": 1, "label": "PARTICIPATES", "end_id": 2, "start_id": 1, "properties": {"from": 2021}}::edge, {"id": 2, "label": "Project", "properties": {"title": "Dashboard"}}::vertex]::path
+(1 row)
+
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) MERGE p=(x)-[r:PARTICIPATES{from:2016}]->(y:Project{title:'Login Rework'}) RETURN p $$) AS (path agtype);
+                                                                                                                                                     path                                                                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [{"id": 1, "label": "Developer", "properties": {"name": "Brian", "surname": "Jones", "yearOfBirth": 1982}}::vertex, {"id": 2, "label": "PARTICIPATES", "end_id": 3, "start_id": 1, "properties": {"from": 2016}}::edge, {"id": 3, "label": "Project", "properties": {"title": "Login Rework"}}::vertex]::path
+(1 row)
+
+SELECT drop_graph('graph1', true);
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to sequence graph1.vertex_id_seq
+drop cascades to table graph1._ag_label_vertex
+drop cascades to sequence graph1.edge_id_seq
+drop cascades to table graph1._ag_label_edge
+drop cascades to table graph1."Developer"
+drop cascades to table graph1."PARTICIPATES"
+drop cascades to table graph1."Project"
+NOTICE:  graph "graph1" has been dropped
+ drop_graph 
+------------
+ 
+(1 row)
+

--- a/regress/sql/label_redesign_wendel.sql
+++ b/regress/sql/label_redesign_wendel.sql
@@ -1,0 +1,27 @@
+--
+-- NOTE: TESTS IN THESE FILE WILL BE MOVED TO EXISTING TEST FILES ONCE THEY ARE UPDATED.
+--
+
+LOAD 'age'; SET search_path TO ag_catalog;
+
+--
+-- Tests entity_exists function and get_label_id_from_entity
+--
+SELECT create_graph('graph1');
+
+SELECT * FROM cypher('graph1', $$ CREATE (:Developer{name:'Brian'}) $$) AS (a agtype);
+
+-- get_label_id_from_entity from set clause
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) SET x.yearOfBirth = 1982, x.surname = 'Jones' RETURN x $$) AS (vertex agtype);
+
+-- entity_exists returning false
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) DELETE (x) CREATE p=(x)-[r:PARTICIPATES{from:2023}]->(y:Project{title:'Documentation'}) RETURN p $$) AS (path agtype);
+
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) DELETE (x) MERGE p=(x)-[r:PARTICIPATES{from:2023}]->(y:Project{title:'Documentation'}) RETURN p $$) AS (path agtype);
+
+-- entity_exists returning true
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) CREATE p=(x)-[r:PARTICIPATES{from:2021}]->(y:Project{title:'Dashboard'}) RETURN p $$) AS (path agtype);
+
+SELECT * FROM cypher('graph1', $$ MATCH (x:Developer) MERGE p=(x)-[r:PARTICIPATES{from:2016}]->(y:Project{title:'Login Rework'}) RETURN p $$) AS (path agtype);
+
+SELECT drop_graph('graph1', true);

--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -155,8 +155,18 @@ int32 get_label_id(const char *label_name, Oid graph_oid)
  */
 int32 get_label_id_from_entity(agtype_value *entity, const char *graph_name)
 {
-    char *label_name;
+    Oid graph_oid;
     graph_cache_data *gcd;
+
+    gcd = search_graph_name_cache(graph_name);
+    graph_oid = get_label_id_from_entity_by_oid(entity, gcd->oid);
+
+    return graph_oid;
+}
+
+int32 get_label_id_from_entity_by_oid(agtype_value *entity, Oid graph_oid)
+{
+    char *label_name;
     label_cache_data *lcd;
     agtype_value *agtv_label;
 
@@ -177,8 +187,7 @@ int32 get_label_id_from_entity(agtype_value *entity, const char *graph_name)
                                                    AG_DEFAULT_LABEL_EDGE;
     }
 
-    gcd = search_graph_name_cache(graph_name);
-    lcd = search_label_name_graph_cache(label_name, gcd->oid);
+    lcd = search_label_name_graph_cache(label_name, graph_oid);
     return lcd->id;
 }
 

--- a/src/backend/executor/cypher_create.c
+++ b/src/backend/executor/cypher_create.c
@@ -594,6 +594,9 @@ static Datum create_vertex(cypher_create_custom_scan_state *css,
                      errmsg("agtype must resolve to a vertex")));
         }
 
+        // extract the label id
+        label_id = get_label_id_from_entity_by_oid(v, css->graph_oid);
+
         // extract the id agtype field
         id_value = GET_AGTYPE_VALUE_OBJECT_VALUE(v, "id");
 
@@ -613,7 +616,7 @@ static Datum create_vertex(cypher_create_custom_scan_state *css,
          */
         if (!SAFE_TO_SKIP_EXISTENCE_CHECK(node->flags))
         {
-            if (!entity_exists(estate, css->graph_oid, DATUM_GET_GRAPHID(id)))
+            if (!entity_exists(estate, css->graph_oid, id, label_id))
             {
                 ereport(ERROR,
                     (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),

--- a/src/backend/executor/cypher_merge.c
+++ b/src/backend/executor/cypher_merge.c
@@ -810,6 +810,9 @@ static Datum merge_vertex(cypher_merge_custom_scan_state *css,
                      errmsg("agtype must resolve to a vertex")));
         }
 
+        // extract the label id
+        label_id = get_label_id_from_entity_by_oid(v, css->graph_oid);
+
         /* extract the id agtype field */
         id_value = GET_AGTYPE_VALUE_OBJECT_VALUE(v, "id");
 
@@ -829,7 +832,7 @@ static Datum merge_vertex(cypher_merge_custom_scan_state *css,
          */
         if (!SAFE_TO_SKIP_EXISTENCE_CHECK(node->flags))
         {
-            if (!entity_exists(estate, css->graph_oid, DATUM_GET_GRAPHID(id)))
+            if (!entity_exists(estate, css->graph_oid, id, label_id))
             {
                 ereport(ERROR,
                     (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),

--- a/src/include/catalog/ag_label.h
+++ b/src/include/catalog/ag_label.h
@@ -81,6 +81,7 @@ void delete_label(Oid relation);
 
 int32 get_label_id(const char *label_name, Oid graph_oid);
 int32 get_label_id_from_entity(agtype_value *entity, const char *graph_name);
+int32 get_label_id_from_entity_by_oid(agtype_value *entity, Oid graph_oid);
 Oid get_label_relation(const char *label_name, Oid graph_oid);
 char *get_label_relation_name(const char *label_name, Oid graph_oid);
 Oid get_label_oid(const char *label_name, Oid label_graph);

--- a/src/include/executor/cypher_utils.h
+++ b/src/include/executor/cypher_utils.h
@@ -105,7 +105,7 @@ ResultRelInfo *create_entity_result_rel_info(EState *estate, char *graph_name,
                                              char *label_name);
 void destroy_entity_result_rel_info(ResultRelInfo *result_rel_info);
 
-bool entity_exists(EState *estate, Oid graph_oid, graphid id);
+bool entity_exists(EState *estate, Oid graph_oid, int64 id, int32 label_id);
 HeapTuple insert_entity_tuple(ResultRelInfo *resultRelInfo,
                               TupleTableSlot *elemTupleSlot,
                               EState *estate);


### PR DESCRIPTION
Added the label id as an argument in `entity_exists`, retrieving label name and getting the label ID passed on that in both `merge_vertex` and `create_vertex` functions. Then, pass label ID to `entity_exists`.
Added the same logic as in `create_vertex` function to `merge_vertex` function 