### PR TITLE
[label_redesign] Fixed a bug (missing label_id)

### DIFF
--- a/src/backend/utils/load/age_load.c
+++ b/src/backend/utils/load/age_load.c
@@ -122,10 +122,11 @@ void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
                         agtype *edge_properties)
 {
 
-    Datum values[6];
-    bool nulls[4] = {false, false, false, false};
+    Datum values[5];
+    bool nulls[5] = {false, false, false, false, false};
     Relation label_relation;
     HeapTuple tuple;
+    int32 label_id;
 
     // Check if label provided exists as vertex label, then throw error
     if (get_label_kind(label_name, graph_oid) == LABEL_KIND_VERTEX)
@@ -134,10 +135,13 @@ void insert_edge_simple(Oid graph_oid, char *label_name, graphid edge_id,
                         errmsg("label %s already exists as vertex label", label_name)));
     }
 
+    label_id = get_label_id(label_name, graph_oid);
+
     values[0] = GRAPHID_GET_DATUM(edge_id);
     values[1] = GRAPHID_GET_DATUM(start_id);
     values[2] = GRAPHID_GET_DATUM(end_id);
     values[3] = AGTYPE_P_GET_DATUM((edge_properties));
+    values[4] = Int32GetDatum(label_id);
 
     label_relation = table_open(get_label_relation(label_name, graph_oid),
                                 RowExclusiveLock);
@@ -154,10 +158,11 @@ void insert_vertex_simple(Oid graph_oid, char *label_name, graphid vertex_id,
                           agtype *vertex_properties)
 {
 
-    Datum values[2];
-    bool nulls[2] = {false, false};
+    Datum values[3];
+    bool nulls[3] = {false, false, false};
     Relation label_relation;
     HeapTuple tuple;
+    int32 label_id;
 
     // Check if label provided exists as edge label, then throw error
     if (get_label_kind(label_name, graph_oid) == LABEL_KIND_EDGE)
@@ -166,8 +171,11 @@ void insert_vertex_simple(Oid graph_oid, char *label_name, graphid vertex_id,
                         errmsg("label %s already exists as edge label", label_name)));
     }
 
+    label_id = get_label_id(label_name, graph_oid);
+
     values[0] = GRAPHID_GET_DATUM(vertex_id);
     values[1] = AGTYPE_P_GET_DATUM((vertex_properties));
+    values[2] = Int32GetDatum(label_id);
 
     label_relation = table_open(get_label_relation(label_name, graph_oid),
                                 RowExclusiveLock);


### PR DESCRIPTION
- This fixes an error: _graph_oid and label_id must not be null_
- It was due to missing `label_id` value for `label_id` column.