### PR TITLE
[Label Redesign] Change the label id column type to int4 array

### DIFF
--- a/regress/expected/label_redesign_rafsun.out
+++ b/regress/expected/label_redesign_rafsun.out
@@ -12,6 +12,31 @@ NOTICE:  graph "graph1" has been created
  
 (1 row)
 
+-- show vertex and edge relation information
+\d+ graph1._ag_label_vertex;
+                                                                           Table "graph1._ag_label_vertex"
+   Column   |   Type    | Collation | Nullable |                                           Default                                            | Storage  | Stats target | Description 
+------------+-----------+-----------+----------+----------------------------------------------------------------------------------------------+----------+--------------+-------------
+ id         | bigint    |           | not null | nextval('graph1.vertex_id_seq'::regclass)                                                    | plain    |              | 
+ properties | agtype    |           | not null | agtype_build_map()                                                                           | extended |              | 
+ label_id   | integer[] |           | not null | agtype_to_int4_array(agtype_build_list(_label_id('graph1'::name, '_ag_label_vertex'::name))) | extended |              | 
+Indexes:
+    "_ag_label_vertex_pkey" PRIMARY KEY, btree (id)
+
+\d+ graph1._ag_label_edge;
+                                                                             Table "graph1._ag_label_edge"
+     Column     |   Type    | Collation | Nullable |                                          Default                                           | Storage  | Stats target | Description 
+----------------+-----------+-----------+----------+--------------------------------------------------------------------------------------------+----------+--------------+-------------
+ id             | bigint    |           | not null | nextval('graph1.edge_id_seq'::regclass)                                                    | plain    |              | 
+ start_id       | bigint    |           | not null |                                                                                            | plain    |              | 
+ end_id         | bigint    |           | not null |                                                                                            | plain    |              | 
+ properties     | agtype    |           | not null | agtype_build_map()                                                                         | extended |              | 
+ label_id       | integer[] |           | not null | agtype_to_int4_array(agtype_build_list(_label_id('graph1'::name, '_ag_label_edge'::name))) | extended |              | 
+ start_label_id | integer[] |           | not null |                                                                                            | extended |              | 
+ end_label_id   | integer[] |           | not null |                                                                                            | extended |              | 
+Indexes:
+    "_ag_label_edge_pkey" PRIMARY KEY, btree (id)
+
 SELECT * FROM cypher('graph1',
 $$
 		CREATE (:Teacher{name:'John'})-[:Teaches{from:2011}]->(:Class{title:'DS'}),
@@ -91,36 +116,6 @@ SELECT * FROM cypher('graph1', $$ MATCH p = ()-[]->() RETURN p $$) AS (result ag
  [{"id": 3, "label": "Student", "properties": {"name": "Smith"}}::vertex, {"id": 2, "label": "Learns", "end_id": 4, "start_id": 3, "properties": {"from": 2013}, "end_label_id": 5, "end_label_name": "Class", "start_label_id": 6, "start_label_name": "Student"}::edge, {"id": 4, "label": "Class", "properties": {"title": "AI"}}::vertex]::path
  [{"id": 5, "label": "", "properties": {"name": "Bob"}}::vertex, {"id": 3, "label": "Learns", "end_id": 6, "start_id": 5, "properties": {"from": 2022}, "end_label_id": 1, "end_label_name": "", "start_label_id": 1, "start_label_name": ""}::edge, {"id": 6, "label": "", "properties": {"title": "Swimming"}}::vertex]::path
 (3 rows)
-
--- show vertex and edge relation information
-\d+ graph1._ag_label_vertex;
-                                                      Table "graph1._ag_label_vertex"
-   Column   |  Type   | Collation | Nullable |                       Default                       | Storage  | Stats target | Description 
-------------+---------+-----------+----------+-----------------------------------------------------+----------+--------------+-------------
- id         | bigint  |           | not null | nextval('graph1.vertex_id_seq'::regclass)           | plain    |              | 
- properties | agtype  |           | not null | agtype_build_map()                                  | extended |              | 
- label_id   | integer |           | not null | _label_id('graph1'::name, '_ag_label_vertex'::name) | plain    |              | 
-Indexes:
-    "_ag_label_vertex_pkey" PRIMARY KEY, btree (id)
-Child tables: graph1."Class",
-              graph1."Student",
-              graph1."Teacher"
-
-\d+ graph1._ag_label_edge;
-                                                        Table "graph1._ag_label_edge"
-     Column     |  Type   | Collation | Nullable |                      Default                      | Storage  | Stats target | Description 
-----------------+---------+-----------+----------+---------------------------------------------------+----------+--------------+-------------
- id             | bigint  |           | not null | nextval('graph1.edge_id_seq'::regclass)           | plain    |              | 
- start_id       | bigint  |           | not null |                                                   | plain    |              | 
- end_id         | bigint  |           | not null |                                                   | plain    |              | 
- properties     | agtype  |           | not null | agtype_build_map()                                | extended |              | 
- label_id       | integer |           | not null | _label_id('graph1'::name, '_ag_label_edge'::name) | plain    |              | 
- start_label_id | integer |           | not null |                                                   | plain    |              | 
- end_label_id   | integer |           | not null |                                                   | plain    |              | 
-Indexes:
-    "_ag_label_edge_pkey" PRIMARY KEY, btree (id)
-Child tables: graph1."Learns",
-              graph1."Teaches"
 
 SELECT drop_graph('graph1', true);
 NOTICE:  drop cascades to 9 other objects

--- a/regress/sql/label_redesign_rafsun.sql
+++ b/regress/sql/label_redesign_rafsun.sql
@@ -9,6 +9,10 @@ LOAD 'age'; SET search_path TO ag_catalog;
 --
 SELECT create_graph('graph1');
 
+-- show vertex and edge relation information
+\d+ graph1._ag_label_vertex;
+\d+ graph1._ag_label_edge;
+
 SELECT * FROM cypher('graph1',
 $$
 		CREATE (:Teacher{name:'John'})-[:Teaches{from:2011}]->(:Class{title:'DS'}),
@@ -35,9 +39,5 @@ SELECT * FROM graph1._ag_label_edge ORDER BY id;
 SELECT * FROM cypher('graph1', $$ MATCH (x) RETURN x $$) AS (result agtype);
 SELECT * FROM cypher('graph1', $$ MATCH ()-[e]->() RETURN e $$) AS (result agtype);
 SELECT * FROM cypher('graph1', $$ MATCH p = ()-[]->() RETURN p $$) AS (result agtype);
-
--- show vertex and edge relation information
-\d+ graph1._ag_label_vertex;
-\d+ graph1._ag_label_edge;
 
 SELECT drop_graph('graph1', true);

--- a/src/backend/commands/label_commands.c
+++ b/src/backend/commands/label_commands.c
@@ -400,9 +400,9 @@ static void create_table_for_label(char *graph_name, char *label_name,
    "start_id" eid NOT NULL
    "end_id" eid NOT NULL
    "properties" agtype NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
-   "label_id" integer NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
-   "start_label_id" integer NOT NULL
-   "end_label_id" integer NOT NULL
+   "label_id" integer array NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
+   "start_label_id" integer array NOT NULL
+   "end_label_id" integer array NOT NULL
  */
 static List *create_edge_table_elements(char *graph_name, char *label_name,
                                         char *schema_name, char *rel_name,
@@ -438,21 +438,21 @@ static List *create_edge_table_elements(char *graph_name, char *label_name,
     props->constraints = list_make2(build_not_null_constraint(),
                                     build_properties_default());
 
-    // "label_id" integer NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
-    label_id = makeColumnDef(AG_EDGE_COLNAME_LABEL_ID, INT4OID, -1,
+    // "label_id" integer array NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
+    label_id = makeColumnDef(AG_EDGE_COLNAME_LABEL_ID, INT4ARRAYOID, -1,
                              InvalidOid);
     label_id->constraints =
         list_make2(build_not_null_constraint(),
                    build_label_id_default(graph_name, label_name));
 
-    // "start_label_id" integer NOT NULL
-    start_label_id = makeColumnDef(AG_EDGE_COLNAME_START_LABEL_ID, INT4OID, -1,
-                                   InvalidOid);
+    // "start_label_id" integer array NOT NULL
+    start_label_id = makeColumnDef(AG_EDGE_COLNAME_START_LABEL_ID,
+                                   INT4ARRAYOID, -1, InvalidOid);
     start_label_id->constraints = list_make1(build_not_null_constraint());
 
-    // "end_label_id" integer NOT NULL
-    end_label_id = makeColumnDef(AG_EDGE_COLNAME_END_LABEL_ID, INT4OID, -1,
-                                 InvalidOid);
+    // "end_label_id" integer array NOT NULL
+    end_label_id = makeColumnDef(AG_EDGE_COLNAME_END_LABEL_ID, INT4ARRAYOID,
+                                 -1, InvalidOid);
     end_label_id->constraints = list_make1(build_not_null_constraint());
 
     column_defs = list_make4(id, start_id, end_id, props);
@@ -466,7 +466,7 @@ static List *create_edge_table_elements(char *graph_name, char *label_name,
 // CREATE TABLE `schema_name`.`rel_name` (
 //   "id" eid PRIMARY KEY DEFAULT nextval(...),
 //   "properties" agtype NOT NULL DEFAULT "ag_catalog"."agtype_build_map"()
-//   "label_id" integer NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
+//   "label_id" integer array NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
 // )
 static List *create_vertex_table_elements(char *graph_name, char *label_name,
                                           char *schema_name, char *rel_name,
@@ -488,8 +488,8 @@ static List *create_vertex_table_elements(char *graph_name, char *label_name,
     props->constraints = list_make2(build_not_null_constraint(),
                                     build_properties_default());
 
-    // "label_id" integer NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
-    label_id = makeColumnDef(AG_VERTEX_COLNAME_LABEL_ID, INT4OID, -1,
+    // "label_id" integer array NOT NULL DEFAULT "ag_catalog"."_label_id(...)"
+    label_id = makeColumnDef(AG_VERTEX_COLNAME_LABEL_ID, INT4ARRAYOID, -1,
                              InvalidOid);
     label_id->constraints =
         list_make2(build_not_null_constraint(),
@@ -637,6 +637,14 @@ static FuncCall *build_label_id_default_func_call(char *graph_name,
     List *label_id_func_args;
     FuncCall *label_id_func;
 
+    List *list_func_name;
+    List *list_func_args;
+    FuncCall *list_func;
+
+    List *list_int4_func_name;
+    List *list_int4_func_args;
+    FuncCall *list_int4_func;
+
     graph_name_const = makeNode(A_Const);
     graph_name_const->val.sval.type = T_String;
     graph_name_const->val.sval.sval = graph_name;
@@ -653,7 +661,23 @@ static FuncCall *build_label_id_default_func_call(char *graph_name,
     label_id_func = makeFuncCall(label_id_func_name, label_id_func_args,
                                  COERCE_SQL_SYNTAX, -1);
 
-    return label_id_func;
+    list_func_name = list_make2(makeString("ag_catalog"),
+                                makeString("agtype_build_list"));
+
+    list_func_args = list_make1(label_id_func);
+
+    list_func = makeFuncCall(list_func_name, list_func_args,
+                             COERCE_SQL_SYNTAX, -1);
+
+    list_int4_func_name = list_make2(makeString("ag_catalog"),
+                                     makeString("agtype_to_int4_array"));
+
+    list_int4_func_args = list_make1(list_func);
+
+    list_int4_func = makeFuncCall(list_int4_func_name, list_int4_func_args,
+                                  COERCE_SQL_SYNTAX, -1);
+
+    return list_int4_func;
 }
 
 // DEFAULT "ag_catalog"."_label_id(...)"


### PR DESCRIPTION
This includes also changing the start_label_id and end_label_id column types to int4 arrays
The `installcheck` command outputs:
![installcheck-output](https://github.com/rafsun42/age/assets/105385638/5fe9c6a5-6fad-4f36-b6d8-8d7af0050207)
